### PR TITLE
sdk: add CD32 and CDTV development headers

### DIFF
--- a/sdk/cd32.sdk
+++ b/sdk/cd32.sdk
@@ -1,0 +1,8 @@
+Short: Commodore CD32 developer kit
+Version: 40.15
+Url: https://www.cd32-allianz.de/downloads/software/CD32_DeveloperKit.lha
+
+cd32_developerkit/CD32-Tools/mpegsup-1/fd/mpeg_lib.fd
+cd32_developerkit/CD32-Tools/mpegsup-1/include/clib/mpeg_protos.h
+cd32_developerkit/CD32-Tools/mpegsup-1/include/devices/mpeg.h
+cd32_developerkit/CD32-Tools/mpegsup-1/include/devices/mpeg.i

--- a/sdk/cdtv.sdk
+++ b/sdk/cdtv.sdk
@@ -1,0 +1,13 @@
+Short: Commodore CDTV developer kit
+Version: 2.0
+Url: https://www.cd32-allianz.de/downloads/software/CDTV_DeveloperKit.lha
+
+copy : cdtv/cdtvtools-11/includes/BOOKMARK.H m68k-amigaos/include/devices/bookmark.h
+copy : cdtv/cdtvtools-11/includes/CDFS.H m68k-amigaos/include/devices/cdfs.h
+copy : cdtv/cdtvtools-11/includes/CDTV.H m68k-amigaos/include/devices/cdtv.h
+copy : cdtv/cdtvtools-11/includes/CDTV.H m68k-amigaos/include/cdtv/cdtv.h
+copy : cdtv/cdtvtools-11/includes/CDTVPREFS.H m68k-amigaos/include/devices/cdtvprefs.h
+copy : cdtv/cdtvtools-11/includes/JOYMOUSE.H m68k-amigaos/include/devices/joymouse.h
+copy : cdtv/cdtvtools-11/includes/KEYCLICK.H m68k-amigaos/include/devices/keyclick.h
+copy : cdtv/cdtvtools-11/includes/SCREENSAVER.H m68k-amigaos/include/devices/screensaver.h
+copy : cdtv/cdtvtools-20/includes/PLAYERPREFS.FD m68k-amigaos/lib/fd/playerprefs_lib.fd

--- a/sdk/install
+++ b/sdk/install
@@ -31,8 +31,20 @@ case $1 in
 					rsync -r projects/$file/* build/$2/
 				else
 					if [ ! -e "download/$file" ]; then
-						echo wget ${a[1]}:${a[2]} -O download/$file
-						wget ${a[1]}:${a[2]} -O download/$file || (rm download/$file; exit 1)
+						url=${a[1]}:${a[2]}
+						if command -v curl >/dev/null 2>&1; then
+							echo curl --fail --location "$url" --output "download/$file"
+							curl --fail --location "$url" --output "download/$file" || {
+								rm -f "download/$file"
+								exit 1
+							}
+						else
+							echo wget "$url" -O "download/$file"
+							wget "$url" -O "download/$file" || {
+								rm -f "download/$file"
+								exit 1
+							}
+						fi
 					fi
 					if [ ! -e "build/$2" ] || [ "$(ls -l build/$2)" == "total 0" ]; then
 						mkdir -p build/$2
@@ -152,6 +164,17 @@ case $1 in
 				patch=patches/$2/${a[1]}
 				echo applying patch $patch to build/$2
 				patch -N -p0 -r - -d build/$2 < $patch
+			;;
+			copy)
+				source_file=${a[1]}
+				destination_file=${a[2]}
+				if [ -z "$source_file" ] || [ -z "$destination_file" ]; then
+					echo "copy requires a source and destination"
+					exit 1
+				fi
+				mkdir -p "$3/$(dirname "$destination_file")"
+				echo cp "build/$2/$source_file" "$3/$destination_file"
+				cp "build/$2/$source_file" "$3/$destination_file" || exit 1
 			;;
 			*)
 				if [ "$line" != "" ]; then


### PR DESCRIPTION
## Summary

- add the compiler-facing MPEG headers and FD from the CD32 developer kit
- add the public CDTV headers with canonical lowercase installation names
- install the CDTV PlayerPrefs FD without unrelated archive contents
- add an explicit SDK descriptor copy rule for case-sensitive destinations
- prefer curl for HTTPS downloads while retaining wget as a fallback

## Rationale

The CD32 and CDTV developer kit archives contain tools, examples,
documentation, and older copies of interfaces already supplied by NDK 3.2.
Installing the archives wholesale would pollute the target prefix and could
replace newer NDK material.

The CDTV headers also use uppercase archive names, while Amiga source expects
lowercase paths such as `cdtv/cdtv.h`. The explicit copy rule lets SDK
descriptors select and rename individual files without adding archive-specific
logic to the installer.

## Validation

- installed both SDK descriptors into a fresh temporary prefix
- verified that only the selected headers and FD files were installed
- compiled all installed C headers with GCC 6.5.0b, 13.4, and 16.1 using
  `-Wall -Wextra -Werror -fsyntax-only`
- ran `bash -n sdk/install`
- ran `shellcheck --severity=error sdk/install`
- ran `git diff --check`
