### PR TITLE
Downgrade zlib to 1.3.1, fetch from the fossils archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ update: update-gcc update-binutils update-fd2sfd update-fd2pragma update-ira upd
 	+$(MAKE) -B $(DOWNLOAD)/vbcc_target_m68k-kick13.lha
 	+$(MAKE) -B $(DOWNLOAD)/$(NDK_ARC_NAME).lha
 	+$(MAKE) -B $(DOWNLOAD)/ixemul-sdk.lha
-	+$(MAKE) -B $(DOWNLOAD)/$(ZLIB).tar.xz
+	+$(MAKE) -B $(DOWNLOAD)/$(ZLIB).tar.gz
 	+$(MAKE) -B $(DOWNLOAD)/$(LIBPNG).tar.xz
 	+$(MAKE) -B $(DOWNLOAD)/$(LIBFREETYPE).tar.xz
 
@@ -1215,7 +1215,7 @@ MULTICONFIGURE = $(L0)"configure $1"$(L1) $(foreach T,$(subst MODNAME,$1,$(MULTI
 # =================================================
 # zlib
 # =================================================
-ZLIB=zlib-1.3.2
+ZLIB=zlib-1.3.1
 
 .PHONY: zlib clean-zlib
 
@@ -1241,12 +1241,12 @@ $(BUILD)/$(ZLIB)/Makefile: $(PROJECTS)/$(ZLIB)/configure
 	$(call MULTICONFIGURE,$(ZLIB),libz.a,)
 	@touch $@
 
-$(PROJECTS)/$(ZLIB)/configure: $(DOWNLOAD)/$(ZLIB).tar.xz
-	tar -C $(PROJECTS) -xf $(DOWNLOAD)/$(ZLIB).tar.xz
+$(PROJECTS)/$(ZLIB)/configure: $(DOWNLOAD)/$(ZLIB).tar.gz
+	tar -C $(PROJECTS) -xf $(DOWNLOAD)/$(ZLIB).tar.gz
 	@touch $@
 
-$(DOWNLOAD)/$(ZLIB).tar.xz:
-	$(call get-file,zlib,https://zlib.net/$(ZLIB).tar.xz,$(ZLIB).tar.xz)
+$(DOWNLOAD)/$(ZLIB).tar.gz:
+	$(call get-file,zlib,https://zlib.net/fossils/$(ZLIB).tar.gz,$(ZLIB).tar.gz)
 
 # =================================================
 # libpng


### PR DESCRIPTION
The zlib 1.3.2 bump breaks the toolchain build: 1.3.2's configure
appends -fPIC to CFLAGS unconditionally on the gcc path, so every
object is compiled as ELF PIC and the m68k-amigaos assembler rejects
the resulting relocations:

    Error: syntax error -- statement `move.l _gzclose_w@GOT(a4),a0' ignored

No flag can override it - configure appends -fPIC after the caller's
CFLAGS, and --static does not help. 1.3.1 keeps -fPIC in SFLAGS
(shared) only, where it belongs, and builds fine:

    CC=m68k-amigaos-gcc CFLAGS='-fbaserel -noixemul' ./configure --static
    make libz.a  # OK on 1.3.1

Since zlib.net only serves the newest tarball at the top level,
older versions have to come from https://zlib.net/fossils/ (gz only).
