### PR TITLE
sdk: update P96 to 3.6.1, add P96 card driver SDK

### DIFF
--- a/sdk/p96.sdk
+++ b/sdk/p96.sdk
@@ -1,6 +1,7 @@
-Short: Picasso96 retargetable graphics system
-Version: 2.3
-Url: http://wiki.icomp.de/w/images/e/e9/Develop.lha
+Short: P96 retargetable graphics system
+Version: 3.6.1
+Url: https://aminet.net/dev/misc/P96Develop.lha
+Sha256: 53d3413653afc58a9b12e8c31b66a8fa096edf3c3de18937f4aa8effd98b4d2b
 
 Picasso96Develop/Include/libraries/Picasso96.i
 Picasso96Develop/Include/libraries/Picasso96.h

--- a/sdk/p96card.sdk
+++ b/sdk/p96card.sdk
@@ -1,0 +1,18 @@
+Short: P96 graphics card driver development files
+Version: 3.6.1
+Url: https://aminet.net/dev/misc/P96CardDevelop.lha
+Sha256: 91352742f88cc9b3aeaaf0cd1f84cb2eade705acfa6365e3a37dd571d8b8f786
+
+copy : Picasso96Develop/PrivateInclude/boardinfo.h m68k-amigaos/include/boardinfo.h
+copy : Picasso96Develop/PrivateInclude/boardinfo.i m68k-amigaos/include/boardinfo.i
+copy : Picasso96Develop/PrivateInclude/settings.h m68k-amigaos/include/settings.h
+copy : Picasso96Develop/PrivateInclude/settings.i m68k-amigaos/include/settings.i
+copy : Picasso96Develop/PrivateInclude/macros.i m68k-amigaos/include/macros.i
+Picasso96Develop/PrivateInclude/clib/Picasso96_card_protos.h
+Picasso96Develop/PrivateInclude/clib/Picasso96_chip_protos.h
+Picasso96Develop/PrivateInclude/inline/Picasso96_chip.h
+Picasso96Develop/PrivateInclude/pragma/Picasso96_chip_lib.h
+Picasso96Develop/PrivateInclude/pragmas/Picasso96_card_pragmas.h
+Picasso96Develop/PrivateInclude/pragmas/Picasso96_chip_pragmas.h
+Picasso96Develop/PrivateInclude/proto/Picasso96_card.h
+Picasso96Develop/PrivateInclude/proto/Picasso96_chip.h


### PR DESCRIPTION
Refresh the P96 SDK to the latest 3.6.1 release and add a separate
p96card.sdk installer for the private headers needed to build
P96 card drivers.

Both are pinned with Sha256 like the other checksummed SDKs,
so we'll detect when the unversioned archives are silently
updated.

Note for anyone rebuilding: `sdk/install` skips unpacking when the
build/<sdk> directory already exists, so a `rm -rf build/p96` is needed
to pick up the new archive on an existing tree.
