### PR TITLE
Add a package rule to tar up the toolchain prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ help:
 	@echo "make clean					remove the build folder"
 	@echo "make clean-<target>				remove the target's build folder"
 	@echo "make drop-prefix				remove all content from the prefix folder"
+	@echo "make package					tar up the prefix folder into m68k-amigaos-gcc-<version>-<os>-<arch>.tar.xz"
 	@echo "make update					perform git pull for all targets"
 	@echo "make update-<target>				perform git pull for the given target"
 	@echo "make sdk=<sdk>					install the sdk <sdk>"
@@ -311,6 +312,13 @@ drop-prefix:
 	rm -rf $(PREFIX)/man
 	rm -rf $(PREFIX)/share
 	@mkdir -p $(PREFIX)/bin
+
+# package the toolchain prefix into a tarball
+PACKAGE ?= m68k-amigaos-gcc-$(GCC_VERSION)-$(UNAME_S)-$(shell uname -m).tar.xz
+.PHONY: package
+package:
+	@test -n "$(GCC_VERSION)" || { echo "GCC_VERSION is empty - run make update first"; exit 1; }
+	XZ_OPT=-T0 tar -C $(dir $(abspath $(PREFIX))) -cJf $(PACKAGE) $(notdir $(abspath $(PREFIX)))
 
 # =================================================
 # update all projects

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ make <target>		      builds a target: binutils, gcc, fd2sfd, fd2pragma, ira, sfd
 make clean		        remove the build folder
 make clean-<target>	  remove the target's build folder
 make drop-prefix	    remove all content from the prefix folder, beware!
+make package		      tar up the prefix folder into m68k-amigaos-gcc-<version>-<os>-<arch>.tar.xz
 make update		        perform git pull for all targets
 make update-<target>	perform git pull for the given target
 ```
@@ -168,6 +169,12 @@ make drop-prefix
 time make all -j4
 ```
 The above commands take roughly 10 minutes on my laptop running Ubuntu yet the same commands take forever running cygwin on Windows.
+
+## Packaging
+`make package` tars up the PREFIX folder into `m68k-amigaos-gcc-<version>-<os>-<arch>.tar.xz`. Override the output path with `PACKAGE=`:
+```
+make package PREFIX=/opt/amiga PACKAGE=/tmp/toolchain.tar.xz
+```
 
 ## Kickstart 1.3
 


### PR DESCRIPTION
Add a `package` rule that tars up the toolchain prefix into
`m68k-amigaos-gcc-<version>-<host_os>-<host_arch>.tar.xz`.

Groundwork for a GitHub workflow that bootstraps the toolchain on a runner and uploads the tarball as an artifact; that part is being tested on a fork and will follow as a separate PR.