### PR TITLE
Anchor the module greps on .repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,8 @@ endif
 # get git urls and branches from .repos file
 $(shell  [ ! -f .repos ] && cp default-repos .repos)
 modules := $(shell cat .repos | $(SED) -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f1)
-get_url = $(shell grep $(1) .repos | $(SED) -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f2)
-get_branch = $(shell grep $(1) .repos | $(SED) -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f3)
+get_url = $(shell grep '^$(1)[[:blank:]]' .repos | $(SED) -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f2)
+get_branch = $(shell grep '^$(1)[[:blank:]]' .repos | $(SED) -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f3)
 $(foreach modu,$(modules),$(eval $(modu)_URL=$(call get_url,$(modu))))
 $(foreach modu,$(modules),$(eval $(modu)_BRANCH=$(call get_branch,$(modu))))
 
@@ -1079,8 +1079,8 @@ $(SDKS): libnix lha
 .PHONY: update-repos
 update-repos:
 	@for i in $(modules); do \
-		url=$$(grep $$i .repos | sed -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f2); \
-		bra=$$(grep $$i .repos | sed -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f3); \
+		url=$$(grep "^$$i[[:blank:]]" .repos | sed -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f2); \
+		bra=$$(grep "^$$i[[:blank:]]" .repos | sed -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f3); \
 		bra=$${bra/$$'\n'} ;\
 		bra=$${bra/$$'\r'} ;\
 		if [ -e projects/$$i ]; then \
@@ -1168,11 +1168,11 @@ v:
 
 # change version to the given branch
 branch:
-	@if [ "" != "$(branch)" ] && [ "1" == "$$(grep -c $(mod) .repos)" ]; then \
+	@if [ "" != "$(branch)" ] && [ "1" == "$$(grep -c '^$(mod)[[:blank:]]' .repos)" ]; then \
 		echo $(mod) $(branch) ; \
-	    url=$$(grep $(mod) .repos | sed -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f2); \
+	    url=$$(grep '^$(mod)[[:blank:]]' .repos | sed -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f2); \
 	    mv .repos .repos.bak; \
-	    grep -v $(mod) .repos.bak > .repos; \
+	    grep -v '^$(mod)[[:blank:]]' .repos.bak > .repos; \
 	    echo "$(mod) $$url $(branch)" >> .repos; \
 	    if [ -d  projects/$(mod) ]; then \
 	      pushd projects/$(mod); \


### PR DESCRIPTION
An unanchored grep lets a URL or branch name containing another module's name match that module's line: `make branch branch=foo-gcc15 mod=libnix` matched both the libnix and gcc lines and corrupted .repos, and the URL/branch lookups have the same exposure. Anchor all of them on the module name at the start of the line.

Verified by running `make branch` with a branch name containing "gcc": the gcc line now survives intact and only the libnix line is rewritten.