### PR TITLE
sdk: fix the filesysbox_lib.fd path for V54.10

### DIFF
--- a/sdk/filesysbox.sdk
+++ b/sdk/filesysbox.sdk
@@ -5,8 +5,8 @@ Url: git://github.com/salass00/filesysbox:V54.10
 include
 include/sys
 include/sys/statvfs.h
-include/fd
-include/fd/filesysbox_lib.fd
+fd
+fd/filesysbox_lib.fd
 include/pragmas
 include/pragmas/filesysbox_pragmas.h
 include/proto


### PR DESCRIPTION
V54.10 moved filesysbox_lib.fd from include/fd/ to fd/ at the repo root, so a fresh `make sdk=filesysbox` failed to install the fd file and then fd2sfd aborted. My earlier V54.10 bump (#38) missed this because the local build tree still had the V54.7 layout cached; the fresh clone in CI caught it.

Verified with `rm -rf build/filesysbox && make sdk=filesysbox NDK=3.2`: the sdk installs cleanly and lib/fd/filesysbox_lib.fd lands in the prefix.