### PR TITLE
sdk/install: make the inline proto include match the generated proto

### DIFF
--- a/sdk/install
+++ b/sdk/install
@@ -193,6 +193,9 @@ case $1 in
 				rm $3/m68k-amigaos/include/proto/$name.h.bak
 				mkdir -p $3/m68k-amigaos/include/inline/
 				$3/bin/sfdc --mode=macros --target=m68k-gcc-amigaos --output=$3/m68k-amigaos/include/inline/$name.h $3/m68k-amigaos/lib/sfd/$sfd || exit 1
+				# sfdc derives the proto include from the SFD basename, which
+				# need not match the proto/<name>.h generated above - fix it up
+				sed -i -e "s|#include <proto/.*\.h>|#include <proto/$name.h>|" $3/m68k-amigaos/include/inline/$name.h
 				$3/bin/sfdc --mode=macros --target=m68kvbcc-amigaos --output=$3/m68k-amigaos/include/inline/${name}_protos.h $3/m68k-amigaos/lib/sfd/$sfd || exit 1
 				mkdir -p $3/m68k-amigaos/include/lvo/
 				$3/bin/sfdc --mode=lvo --target=m68k-amigaos --output=$3/m68k-amigaos/include/lvo/$name.i $3/m68k-amigaos/lib/sfd/$sfd || exit 1


### PR DESCRIPTION
Since the sfdc upstream sync stopped lowercasing the SFD basename (adtools' "do not lowercase basename"), the generated gcc inline headers include `<proto/<Basename>.h>` while sdk/install writes the proto as `proto/<name>.h` derived from the SFD file name. Every sdk with a CamelCase basename is affected: cybergraphics.h included `<proto/CyberGfx.h>`, plus `Camd.h`, `MHI.h`, `CDPlayer.h`, `MC68040.h`, `MMU.h`, `Disassembler.h`, `Warp3D.h` and friends - none of which exist. Anything including an inline header directly (e.g. p96cts) fails to compile.

Rewrite the proto include in the generated inline header to the proto file sdk/install itself generates two lines earlier, which makes the pair self-consistent regardless of how sfdc derives the basename. The NDK inline headers are unaffected (their SFD basenames are lowercase).

Verified by rebuilding the cgx and mmu sdks: the includes now resolve, and a file with a direct `#include <inline/cybergraphics.h>` compiles.