### PR TITLE
sdk: drop the cybergfx sed fixups

### DIFF
--- a/sdk/cgx.sdk
+++ b/sdk/cgx.sdk
@@ -9,6 +9,6 @@ CGraphX/C/Include/cybergraphx/cybergraphics.h
 CGraphX/C/Include/pragmas/cybergraphics_pragmas.h
 CGraphX/FD/cybergraphics_lib.fd = cybergraphics.fd 
 fd2sfd : cybergraphics.fd clib/cybergraphics_protos.h
-sfdc : cybergraphics.sfd cybergfx cybergraphics
+sfdc : cybergraphics.sfd
 stubs : cybergraphics.sfd
 symlink : include/cybergraphx include/cybergraphics

--- a/sdk/filesysbox.sdk
+++ b/sdk/filesysbox.sdk
@@ -21,5 +21,5 @@ include/defines
 include/defines/filesysbox.h
 stdargs : include/clib/filesysbox_protos.h
 fd2sfd : filesysbox_lib.fd clib/filesysbox_protos.h
-sfdc : filesysbox_lib.sfd cybergfx cybergraphics
+sfdc : filesysbox_lib.sfd
 stubs : filesysbox_lib.sfd


### PR DESCRIPTION
Depends on AmigaPorts/fd2sfd#1: with ==libname derived from the FD file name, sfdc generates the correct proto include for cgx directly, so its `cybergfx cybergraphics` fixup args become dead weight. The filesysbox copy of the same args never matched anything (its generated proto/inline contain no cyber references at all).

The remaining two fixups (guigfx, mui) rewrite only the `interfaces/<basename>.h` include inside the `#ifdef __amigaos4__` block of the proto header, which this m68k toolchain never compiles; they can go in a later cleanup together with the choice between the sdk/install include rewrite (#44) and sfdc --protoname (AmigaPorts/sfdc#6).

Verified in a full CI bootstrap with fd2sfd#1 pinned in: https://github.com/codewiz/m68k-amigaos-gcc/actions/runs/32328342919 - the artifact's cybergraphics.sfd has the correct ==libname, inline/cybergraphics.h includes proto/cybergraphics.h, and libstubs.a's autoopen stub now opens "cybergraphics.library" instead of the nonexistent "CyberGfx.library".