### PR TITLE
Makefile: drop the vestigial lib__m__.a symlinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1033,7 +1033,6 @@ $(BUILD)/newlib/newlib/libc.a: $(BUILD)/newlib/newlib/Makefile $(BUILD)/binutils
 	@rsync -a --no-group $(PROJECTS)/newlib-cygwin/newlib/libc/sys/amigaos/include/stabs.h $(PREFIX)/$(TARGET)/sys-include
 	$(L0)"make newlib"$(L1) $(MAKE) -C $(BUILD)/newlib/newlib $(L2)
 	$(L0)"install newlib"$(L1) $(MAKE) -C $(BUILD)/newlib/newlib install $(L2)
-	@for x in $$(find $(PREFIX)/$(TARGET)/lib/* -name libm.a); do ln -sf $$x $${x%*m.a}__m__.a; done
 	@touch $@
 
 $(BUILD)/newlib/newlib/Makefile: $(PROJECTS)/newlib-cygwin/newlib/configure $(BUILD)/ndk-include_ndk $(BUILD)/gcc/_done


### PR DESCRIPTION
The newlib install rule created lib__m__.a symlinks in every multilib dir "to be used by the compiler as fallback" (41e774a, 2019), but no gcc branch from amiga6 to amiga16.2 ever referenced -l__m__, and the link points at libm.a itself, so it adds nothing over -lm.

Bebbo confirmed on https://codeberg.org/bebbo/amiga-gcc/issues/23 that they are a leftover from when libnix did not contain the math functions itself, and has removed the line upstream as well.

This replaces the earlier version of this PR that merely made the links relative: the absolute targets embedded the build prefix, so packaged toolchains shipped 14 dangling symlinks.