### PR TITLE
Build and release the toolchain on macOS arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,20 @@ on:
 
 jobs:
   # Bootstrap the toolchain and run the gcc testsuite as a release gate;
-  # the tarball is uploaded as the workflow artifact we publish below.
-  build:
+  # the tarballs are uploaded as the workflow artifacts we publish below.
+  build-linux:
     uses: ./.github/workflows/toolchain.yml
     with:
       run_testsuite: true
 
+  # the testsuite only runs on Linux; the macOS build gates on compiling
+  build-macos:
+    uses: ./.github/workflows/toolchain.yml
+    with:
+      runner: macos-15
+
   release:
-    needs: build
+    needs: [build-linux, build-macos]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -25,10 +31,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download toolchain tarball
+      - name: Download toolchain tarballs
         uses: actions/download-artifact@v7
         with:
-          name: m68k-amigaos-gcc-amiga16.2-linux-x86_64
+          pattern: m68k-amigaos-gcc-*
+          merge-multiple: true
 
       - name: Create release
         env:
@@ -59,5 +66,5 @@ jobs:
             echo
             git log --pretty=format:"- %h: %s" "$RANGE"
           } > notes.md
-          gh release create "$TAG" m68k-amigaos-gcc-*-Linux-x86_64.tar.xz \
+          gh release create "$TAG" m68k-amigaos-gcc-*.tar.xz \
             --title "Release ${TAG#v}" --notes-file notes.md

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -46,7 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install build dependencies
+      - name: Install build dependencies (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -54,7 +55,23 @@ jobs:
             gettext git libgmp-dev libmpfr-dev libmpc-dev libncurses-dev \
             rsync wget xz-utils
 
+      # bison and make are keg-only or shadowed by Apple's old versions,
+      # so put the brew ones on PATH for the following steps
+      - name: Install build dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install autoconf automake bison flex gettext gmp mpfr \
+            libmpc gnu-sed make wget xz
+          echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix flex)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH
+
+      - name: Set build parallelism
+        run: echo "NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu)" >> $GITHUB_ENV
+
       # skip if present: self-hosted runners keep state between runs
+      # (built from source everywhere: brew only has lhasa, which cannot
+      # create archives and parses some options differently)
       - name: Build and install lha
         run: |
           command -v lha >/dev/null && exit 0
@@ -63,7 +80,7 @@ jobs:
           cd /tmp/lha
           autoreconf -vfi
           ./configure
-          make -j $(nproc)
+          make -j $NPROC
           sudo make install
 
       - name: Select gcc branch
@@ -78,7 +95,7 @@ jobs:
       - name: Build toolchain
         run: |
           mkdir -p $PREFIX
-          make -j $(nproc) all NDK=$NDK PREFIX=$PREFIX MAKEINFO=true
+          make -j $NPROC all NDK=$NDK PREFIX=$PREFIX MAKEINFO=true
 
       # modest -j: downloads are network bound, and more jobs just garble the log
       - name: Install SDKs
@@ -86,7 +103,7 @@ jobs:
 
       # vbcc/vlink/vasm plus the vbcc target archives and vc.config
       - name: Build vbcc toolchain
-        run: make -j $(nproc) vbcc vlink NDK=$NDK PREFIX=$PREFIX MAKEINFO=true
+        run: make -j $NPROC vbcc vlink NDK=$NDK PREFIX=$PREFIX MAKEINFO=true
 
       # name release tarballs after the tag: it versions the whole
       # distribution, while gcc's BASE-VER only moves with gcc itself
@@ -102,8 +119,8 @@ jobs:
       - name: Upload toolchain tarball
         uses: actions/upload-artifact@v7
         with:
-          name: m68k-amigaos-gcc-${{ inputs.gcc_branch }}-linux-x86_64
-          path: m68k-amigaos-gcc-*-Linux-x86_64.tar.xz
+          name: m68k-amigaos-gcc-${{ inputs.gcc_branch }}-${{ runner.os }}-${{ runner.arch }}
+          path: m68k-amigaos-gcc-*.tar.xz
           compression-level: 0
           if-no-files-found: error
 
@@ -115,22 +132,23 @@ jobs:
           path: log/
           if-no-files-found: ignore
 
+      # the vamos testsuite setup is Linux-only for now
       - name: Install testsuite dependencies
-        if: inputs.run_testsuite
+        if: inputs.run_testsuite && runner.os == 'Linux'
         run: |
           sudo apt-get install -y --no-install-recommends dejagnu python3-dev python3-venv
           python3 -m venv $HOME/amitools-venv
           $HOME/amitools-venv/bin/pip install "amitools[vamos] @ ${{ inputs.amitools_git }}"
 
       - name: Run the gcc testsuite
-        if: inputs.run_testsuite
+        if: inputs.run_testsuite && runner.os == 'Linux'
         run: |
           echo "lappend boards_dir \"$PWD/baseboards\"" > dejagnu-site.exp
           env DEJAGNU=$PWD/dejagnu-site.exp PATH="$HOME/amitools-venv/bin:$PATH" \
-            make -j $(nproc) check MAKEINFO=true PREFIX=$PREFIX
+            make -j $NPROC check MAKEINFO=true PREFIX=$PREFIX
 
       - name: Testsuite summary
-        if: always() && inputs.run_testsuite
+        if: always() && inputs.run_testsuite && runner.os == 'Linux'
         run: |
           sum=$(ls build-*/gcc/gcc/testsuite/gcc/gcc.sum) || exit 0
           echo '```' >> $GITHUB_STEP_SUMMARY
@@ -140,7 +158,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload testsuite results
-        if: always() && inputs.run_testsuite
+        if: always() && inputs.run_testsuite && runner.os == 'Linux'
         uses: actions/upload-artifact@v7
         with:
           name: testsuite-results

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -55,16 +55,19 @@ jobs:
             gettext git libgmp-dev libmpfr-dev libmpc-dev libncurses-dev \
             rsync wget xz-utils
 
-      # bison and make are keg-only or shadowed by Apple's old versions,
-      # so put the brew ones on PATH for the following steps
+      # Apple ships old or BSD versions of most build tools; put the brew
+      # GNU ones first on PATH under their plain names (gnubin) so the
+      # build machinery does not need BSD workarounds
       - name: Install build dependencies (macOS)
         if: runner.os == 'macOS'
         run: |
-          brew install autoconf automake bison flex gettext gmp mpfr \
-            libmpc gnu-sed make wget xz
+          brew install autoconf automake bison coreutils flex gettext \
+            gmp gnu-sed gnu-tar grep make mpfr libmpc wget xz
           echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
           echo "$(brew --prefix flex)/bin" >> $GITHUB_PATH
-          echo "$(brew --prefix make)/libexec/gnubin" >> $GITHUB_PATH
+          for pkg in coreutils gnu-sed gnu-tar grep make; do
+            echo "$(brew --prefix $pkg)/libexec/gnubin" >> $GITHUB_PATH
+          done
 
       - name: Set build parallelism
         run: echo "NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu)" >> $GITHUB_ENV

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -131,7 +131,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: build-logs
+          name: build-logs-${{ runner.os }}
           path: log/
           if-no-files-found: ignore
 

--- a/Makefile
+++ b/Makefile
@@ -1096,8 +1096,8 @@ $(SDKS): libnix lha
 .PHONY: update-repos
 update-repos:
 	@for i in $(modules); do \
-		url=$$(grep "^$$i[[:blank:]]" .repos | sed -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f2); \
-		bra=$$(grep "^$$i[[:blank:]]" .repos | sed -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f3); \
+		url=$$(grep "^$$i[[:blank:]]" .repos | $(SED) -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f2); \
+		bra=$$(grep "^$$i[[:blank:]]" .repos | $(SED) -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f3); \
 		bra=$${bra/$$'\n'} ;\
 		bra=$${bra/$$'\r'} ;\
 		if [ -e projects/$$i ]; then \
@@ -1161,7 +1161,7 @@ b:
 v:
 	@D="$(date)"; \
 	for i in $(modules); do \
-		bra=$$(grep $$i .repos | sed -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f3); \
+		bra=$$(grep $$i .repos | $(SED) -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f3); \
 		bra=$${bra/$$'\n'} ;\
 		bra=$${bra/$$'\r'} ;\
 		if [ -e projects/$$i ]; then \
@@ -1187,7 +1187,7 @@ v:
 branch:
 	@if [ "" != "$(branch)" ] && [ "1" == "$$(grep -c '^$(mod)[[:blank:]]' .repos)" ]; then \
 		echo $(mod) $(branch) ; \
-	    url=$$(grep '^$(mod)[[:blank:]]' .repos | sed -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f2); \
+	    url=$$(grep '^$(mod)[[:blank:]]' .repos | $(SED) -e 's/[[:blank:]]\+/ /g' | cut -d' ' -f2); \
 	    mv .repos .repos.bak; \
 	    grep -v '^$(mod)[[:blank:]]' .repos.bak > .repos; \
 	    echo "$(mod) $$url $(branch)" >> .repos; \

--- a/Makefile
+++ b/Makefile
@@ -425,10 +425,10 @@ CONFIG_BINUTILS += --enable-plugins
 # autodetection has produced readelf link failures on some hosts.
 CONFIG_BINUTILS += --without-msgpack
 
-# FreeBSD, OSX : libs added by the command brew install gmp
+# FreeBSD, OSX : libs added by the command brew install gmp mpfr
 ifeq (Darwin, $(findstring Darwin, $(UNAME_S)))
 	BREW_PREFIX := $$(brew --prefix)
-	CONFIG_BINUTILS += --with-libgmp-prefix=$(BREW_PREFIX)
+	CONFIG_BINUTILS += --with-gmp=$(BREW_PREFIX) --with-mpfr=$(BREW_PREFIX)
 endif
 
 ifeq (FreeBSD, $(findstring FreeBSD, $(UNAME_S)))


### PR DESCRIPTION
Follow-up to #46: the bootstrap workflow now also runs on the free macOS arm64 GitHub runners, and tag pushes publish a Darwin-arm64 tarball next to the Linux one.

- workflow: install build dependencies via brew, with the GNU coreutils/sed/tar/grep/make gnubin directories on PATH so the build machinery needs no BSD workarounds; lha is built from source on both OSes
- Makefile: parse .repos with $(SED) (BSD sed has no \+), and pass --with-gmp/--with-mpfr to binutils-gdb on Darwin (--with-libgmp-prefix is not a binutils option)
- release: build on both platforms and attach both tarballs; the testsuite gates the Linux build only

A full macOS build takes about 50 minutes on the 3-core runners, using clang as the host compiler. Exercised by the v16.2-rc3 release on the codewiz fork, which produced both tarballs from one tag push.