### PR TITLE
build: ship lha in the toolchain prefix

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -3,9 +3,9 @@ name: Bootstrap toolchain
 on:
   workflow_dispatch:
     inputs:
-      gcc_branch:
-        description: gcc branch to build
-        default: amiga16.2
+      gcc_version:
+        description: gcc version to build (branch amiga<version>)
+        default: "16.2"
         required: true
       run_testsuite:
         description: run the gcc testsuite under vamos
@@ -21,9 +21,9 @@ on:
   # share the workflow_dispatch input declarations
   workflow_call:
     inputs:
-      gcc_branch:
+      gcc_version:
         type: string
-        default: amiga16.2
+        default: "16.2"
       run_testsuite:
         type: boolean
         default: false
@@ -40,11 +40,18 @@ jobs:
     timeout-minutes: 300
     env:
       NDK: "3.2"
+      # not GCC_VERSION: the Makefile reads that from gcc's BASE-VER
+      # (16.2.0b) for gcc's own lib/gcc/<target>/<version> layout
+      GCC_VER: ${{ inputs.gcc_version || '16.2' }}
       # aminet.net picks a random mirror per download, some broken or
       # slow; pin one that is fast and healthy from the CI runners
       AMINET_MIRROR: http://nl.aminet.net
     steps:
       - uses: actions/checkout@v7
+
+      # PREFIX and NDK reach every make invocation through the environment
+      - name: Set prefix
+        run: echo "PREFIX=$HOME/m68k-amigaos-gcc-$GCC_VER" >> $GITHUB_ENV
 
       - name: Install build dependencies (Linux)
         if: runner.os == 'Linux'
@@ -72,57 +79,38 @@ jobs:
       - name: Set build parallelism
         run: echo "NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu)" >> $GITHUB_ENV
 
-      # skip if present: self-hosted runners keep state between runs
-      # (built from source everywhere: brew only has lhasa, which cannot
-      # create archives and parses some options differently)
-      - name: Build and install lha
-        run: |
-          command -v lha >/dev/null && exit 0
-          rm -rf /tmp/lha
-          git clone --depth 1 https://github.com/jca02266/lha.git /tmp/lha
-          cd /tmp/lha
-          autoreconf -vfi
-          ./configure
-          make -j $NPROC
-          sudo make install
-
       - name: Select gcc branch
-        run: make branch branch=${{ inputs.gcc_branch }} mod=gcc
+        run: make branch branch=amiga$GCC_VER mod=gcc
 
       - name: Fetch sources
-        run: make update NDK=$NDK
-
-      - name: Set versioned prefix
-        run: echo "PREFIX=$HOME/m68k-amigaos-gcc-$(cat projects/gcc/gcc/BASE-VER)" >> $GITHUB_ENV
+        run: make update
 
       - name: Build toolchain
-        run: |
-          mkdir -p $PREFIX
-          make -j $NPROC all NDK=$NDK PREFIX=$PREFIX MAKEINFO=true
+        run: make -j $NPROC all MAKEINFO=true
 
       # modest -j: downloads are network bound, and more jobs just garble the log
       - name: Install SDKs
-        run: make -j4 all-sdk NDK=$NDK PREFIX=$PREFIX MAKEINFO=true
+        run: make -j4 all-sdk MAKEINFO=true
 
       # vbcc/vlink/vasm plus the vbcc target archives and vc.config
       - name: Build vbcc toolchain
-        run: make -j $NPROC vbcc vlink NDK=$NDK PREFIX=$PREFIX MAKEINFO=true
+        run: make -j $NPROC vbcc vlink MAKEINFO=true
 
-      # name release tarballs after the tag: it versions the whole
-      # distribution, while gcc's BASE-VER only moves with gcc itself
+      # release tarballs are named after the tag (16.2-rc4), which
+      # versions the whole distribution rather than just gcc
       - name: Package
         run: |
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
-            make package PREFIX=$PREFIX \
+            make package \
               PACKAGE=m68k-amigaos-gcc-${GITHUB_REF_NAME#v}-$(uname -s)-$(uname -m).tar.xz
           else
-            make package PREFIX=$PREFIX
+            make package
           fi
 
       - name: Upload toolchain tarball
         uses: actions/upload-artifact@v7
         with:
-          name: m68k-amigaos-gcc-${{ inputs.gcc_branch }}-${{ runner.os }}-${{ runner.arch }}
+          name: m68k-amigaos-gcc-${{ env.GCC_VER }}-${{ runner.os }}-${{ runner.arch }}
           path: m68k-amigaos-gcc-*.tar.xz
           compression-level: 0
           if-no-files-found: error
@@ -148,7 +136,7 @@ jobs:
         run: |
           echo "lappend boards_dir \"$PWD/baseboards\"" > dejagnu-site.exp
           env DEJAGNU=$PWD/dejagnu-site.exp PATH="$HOME/amitools-venv/bin:$PATH" \
-            make -j $NPROC check MAKEINFO=true PREFIX=$PREFIX
+            make -j $NPROC check MAKEINFO=true
 
       - name: Testsuite summary
         if: always() && inputs.run_testsuite && runner.os == 'Linux'

--- a/Makefile
+++ b/Makefile
@@ -703,19 +703,20 @@ $(BUILD)/vlink/Makefile: $(PROJECTS)/vlink/Makefile
 $(PROJECTS)/vlink/Makefile:
 	@cd $(PROJECTS) &&	git clone -b $(vlink_BRANCH) --depth 4 $(vlink_URL)
 
-.PHONY: lha
-lha: $(BUILD)/_lha_done
+# Always built, so the toolchain ships its own lha instead of relying
+# on the host: brew only has lhasa, which cannot create archives and
+# parses some options differently
+LHA := $(PREFIX)/bin/lha$(EXEEXT)
 
-$(BUILD)/_lha_done:
-	@if [ ! -e "$$(which lha 2>/dev/null)" ]; then \
-	  cd $(BUILD) && rm -rf lha; \
-	  $(L00)"clone lha"$(L1) git clone -b $(lha_BRANCH) $(lha_URL); $(L2); \
-	  cd lha; \
-	  $(L00)"configure lha"$(L1) aclocal; autoheader; automake -a; autoconf; ./configure; $(L2); \
-	  $(L00)"make lha"$(L1) make all; $(L2); \
-	  $(L00)"install lha"$(L1) mkdir -p $(PREFIX)/bin/; install src/lha$(EXEEXT) $(PREFIX)/bin/lha$(EXEEXT); $(L2); \
-	fi
-	@echo "done" >$@
+.PHONY: lha
+lha: $(LHA)
+
+$(LHA):
+	@mkdir -p $(BUILD) && rm -rf $(BUILD)/lha
+	$(L0)"clone lha"$(L1) cd $(BUILD) && git clone -b $(lha_BRANCH) --depth 1 $(lha_URL) $(L2)
+	$(L0)"configure lha"$(L1) cd $(BUILD)/lha && autoreconf -fi && ./configure $(L2)
+	$(L0)"make lha"$(L1) cd $(BUILD)/lha && $(MAKE) all $(L2)
+	$(L0)"install lha"$(L1) mkdir -p $(PREFIX)/bin && install $(BUILD)/lha/src/lha$(EXEEXT) $(LHA) $(L2)
 
 
 .PHONY: vbcc-target
@@ -746,11 +747,11 @@ $(BUILD)/vbcc_target_m68k-amigaos/_done: $(BUILD)/vbcc_target_m68k-amigaos.info 
 	@echo "done" >$@
 
 
-$(BUILD)/vbcc_target_m68k-kick13.info: $(DOWNLOAD)/vbcc_target_m68k-kick13.lha $(BUILD)/_lha_done
+$(BUILD)/vbcc_target_m68k-kick13.info: $(DOWNLOAD)/vbcc_target_m68k-kick13.lha $(LHA)
 	$(L0)"unpack vbcc_target_m68k-kick13"$(L1) cd $(BUILD) && lha xf $(DOWNLOAD)/vbcc_target_m68k-kick13.lha $(L2)
 	@touch $(BUILD)/vbcc_target_m68k-kick13.info
 
-$(BUILD)/vbcc_target_m68k-amigaos.info: $(DOWNLOAD)/vbcc_target_m68k-amigaos.lha $(BUILD)/_lha_done
+$(BUILD)/vbcc_target_m68k-amigaos.info: $(DOWNLOAD)/vbcc_target_m68k-amigaos.lha $(LHA)
 	$(L0)"unpack vbcc_target_m68k-amigaos"$(L1) cd $(BUILD) && lha xf $(DOWNLOAD)/vbcc_target_m68k-amigaos.lha $(L2)
 	@touch $(BUILD)/vbcc_target_m68k-amigaos.info
 
@@ -841,7 +842,7 @@ $(BUILD)/ndk-include_proto: $(PROJECTS)/$(NDK_FOLDER_NAME).info
 	@mkdir -p $(BUILD)/ndk-include/
 	@echo "done" >$@
 
-$(PROJECTS)/$(NDK_FOLDER_NAME).info: $(BUILD)/_lha_done $(DOWNLOAD)/$(NDK_ARC_NAME).lha $(shell find 2>/dev/null patches/$(NDK_FOLDER_NAME)/ -type f)
+$(PROJECTS)/$(NDK_FOLDER_NAME).info: $(LHA) $(DOWNLOAD)/$(NDK_ARC_NAME).lha $(shell find 2>/dev/null patches/$(NDK_FOLDER_NAME)/ -type f)
 	$(L0)"unpack ndk"$(L1) cd $(PROJECTS) && if [[ $(NDK_ARC_NAME) == "NDK3.2" ]] ; \
 	   then mkdir NDK3.2 ; cd NDK3.2 ; fi ; \
 	   lha xf $(DOWNLOAD)/$(NDK_ARC_NAME).lha $(L2)
@@ -1068,7 +1069,7 @@ $(PREFIX)/$(TARGET)/ixemul/lib/libc.a: $(BUILD)/ixemul/lib/libc.a
 	$(L0)"installing ixemul-sdk"$(L1) rsync -a --no-group $(BUILD)/ixemul/* $(PREFIX)/$(TARGET)/ixemul/ $(L2)
 
 
-$(BUILD)/ixemul/lib/libc.a: $(DOWNLOAD)/ixemul-sdk.lha
+$(BUILD)/ixemul/lib/libc.a: $(DOWNLOAD)/ixemul-sdk.lha $(LHA)
 	@mkdir -p $(BUILD)/ixemul
 	$(L0)"unpacking ixemul-sdk.lha"$(L1) cd $(BUILD)/ixemul && lha xf $(DOWNLOAD)/ixemul-sdk.lha $(L2)
 
@@ -1079,7 +1080,7 @@ $(DOWNLOAD)/ixemul-sdk.lha:
 # sdk installation
 # =================================================
 .PHONY: sdk all-sdk
-sdk: libnix $(BUILD)/_lha_done
+sdk: libnix $(LHA)
 	$(L0)"sdk $(sdk)"$(L1) $(PWD)/sdk/install install $(sdk) $(PREFIX) $(L2)
 
 SDKS0=$(shell find sdk/*.sdk)


### PR DESCRIPTION
The lha target only built and installed lha when the host had none, so the result depended on the build machine and the toolchain tarball never shipped bin/lha. Build it unconditionally, with the installed binary as the make target, and let a failure in configure or make actually fail the build (the old semicolon chain did not). The ixemul unpack rule now depends on lha like the other unpack rules.

The workflow no longer installs lha on the runners. Since make update now needs PREFIX (it unpacks the NDK, which builds lha), the prefix is named after a gcc_version input (default 16.2, branch amiga16.2) and set before anything is fetched, instead of being derived from BASE-VER afterwards. PREFIX, NDK and MAKEINFO travel through the job environment, so the make lines lose their repeated arguments. The unpacked tarball directory becomes m68k-amigaos-gcc-16.2; gcc's own lib/gcc/m68k-amigaos/16.2.0b layout inside is unchanged.

Depends on AmigaPorts/lha#1 for the macOS build: the mirror lacks the upstream clang fixes.