### PR TITLE
sdk: do not install the filesysbox statvfs.h

### DIFF
--- a/sdk/filesysbox.sdk
+++ b/sdk/filesysbox.sdk
@@ -3,8 +3,6 @@ Version: 54.10
 Url: git://github.com/salass00/filesysbox:V54.10
 
 include
-include/sys
-include/sys/statvfs.h
 fd
 fd/filesysbox_lib.fd
 include/pragmas


### PR DESCRIPTION
The filesysbox SDK installs include/sys/statvfs.h into m68k-amigaos/include.

It is a fallback for compilers without a libc header: libnix and newlib ship their own sys/statvfs.h (found first), clib2 has none and no statvfs() either.

## Problem

The copy in the generic include is what libstdc++ builds against, so rebuilding gcc into a prefix that already has the SDK fails:

    libstdc++-v3/src/c++17/fs_ops.cc:51: ... candidate 1: 'statvfs::statvfs()' ... candidate expects 0 arguments, 2 provided

libstdc++'s configure finds the header, enables the statvfs() code path, and C++ resolves the call as a constructor because the fallback declares the struct only. A fresh bootstrap never hits this since gcc is built before any SDK.

## Fix

Drop the header from the descriptor. The only build it served was -mcrt=clib2 against libraries/filesysbox.h, which now fails with a clear missing-header error instead of compiling against a struct clib2 cannot fill.

The struct statvfs layout also differs from libnix's, which is being sorted out on the filesysbox.library side: https://github.com/salass00/filesysbox/issues/49