### PR TITLE
build: refuse stale build trees, and build pull requests on demand

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -33,12 +33,19 @@ on:
       runner:
         type: string
         default: ubuntu-24.04
+  # label a pull request "ci" for a macOS build of its merge commit, or
+  # "ci-testsuite" for a Linux build with the gcc testsuite
+  pull_request:
+    types: [labeled]
 
 jobs:
   build:
-    runs-on: ${{ inputs.runner || 'ubuntu-24.04' }}
+    if: github.event_name != 'pull_request' || startsWith(github.event.label.name, 'ci')
+    runs-on: ${{ inputs.runner || (github.event.label.name == 'ci' && 'macos-15') || 'ubuntu-24.04' }}
     timeout-minutes: 300
     env:
+      RUN_TESTSUITE: ${{ inputs.run_testsuite || github.event.label.name == 'ci-testsuite' }}
+      AMITOOLS_GIT: ${{ inputs.amitools_git || 'git+https://github.com/AmigaPorts/amitools.git' }}
       NDK: "3.2"
       # not GCC_VERSION: the Makefile reads that from gcc's BASE-VER
       # (16.2.0b) for gcc's own lib/gcc/<target>/<version> layout
@@ -125,21 +132,21 @@ jobs:
 
       # the vamos testsuite setup is Linux-only for now
       - name: Install testsuite dependencies
-        if: inputs.run_testsuite && runner.os == 'Linux'
+        if: env.RUN_TESTSUITE == 'true' && runner.os == 'Linux'
         run: |
           sudo apt-get install -y --no-install-recommends dejagnu python3-dev python3-venv
           python3 -m venv $HOME/amitools-venv
-          $HOME/amitools-venv/bin/pip install "amitools[vamos] @ ${{ inputs.amitools_git }}"
+          $HOME/amitools-venv/bin/pip install "amitools[vamos] @ $AMITOOLS_GIT"
 
       - name: Run the gcc testsuite
-        if: inputs.run_testsuite && runner.os == 'Linux'
+        if: env.RUN_TESTSUITE == 'true' && runner.os == 'Linux'
         run: |
           echo "lappend boards_dir \"$PWD/baseboards\"" > dejagnu-site.exp
           env DEJAGNU=$PWD/dejagnu-site.exp PATH="$HOME/amitools-venv/bin:$PATH" \
             make -j $NPROC check MAKEINFO=true
 
       - name: Testsuite summary
-        if: always() && inputs.run_testsuite && runner.os == 'Linux'
+        if: always() && env.RUN_TESTSUITE == 'true' && runner.os == 'Linux'
         run: |
           sum=$(ls build-*/gcc/gcc/testsuite/gcc/gcc.sum) || exit 0
           echo '```' >> $GITHUB_STEP_SUMMARY
@@ -149,7 +156,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
 
       - name: Upload testsuite results
-        if: always() && inputs.run_testsuite && runner.os == 'Linux'
+        if: always() && env.RUN_TESTSUITE == 'true' && runner.os == 'Linux'
         uses: actions/upload-artifact@v7
         with:
           name: testsuite-results

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,24 @@ BUILD := $(shell pwd)/build-$(UNAME_S)-$(TARGET)
 PROJECTS := $(shell pwd)/projects
 DOWNLOAD := $(shell pwd)/download
 __BUILDDIR := $(shell mkdir -p $(BUILD))
+
+# binutils, gcc and newlib record the prefix in their configured build
+# trees: building the same tree for another PREFIX installs into both
+PREFIX_STAMP := $(BUILD)/.prefix
+ifeq ($(filter clean% drop-prefix help info update% branch,$(MAKECMDGOALS)),)
+ifneq ($(wildcard $(PREFIX_STAMP)),)
+ifneq ($(shell cat $(PREFIX_STAMP)),$(abspath $(PREFIX)))
+$(error $(BUILD) was configured for PREFIX=$(shell cat $(PREFIX_STAMP)); use that PREFIX, another BUILD, or make clean)
+endif
+# the _done stamps describe what was installed there
+ifeq ($(wildcard $(PREFIX)),)
+$(error $(BUILD) was configured for PREFIX=$(PREFIX), which no longer exists; run make clean first)
+endif
+endif
+endif
+
+$(PREFIX_STAMP):
+	@echo "$(abspath $(PREFIX))" >$@
 __PROJECTDIR := $(shell mkdir -p $(PROJECTS))
 __DOWNLOADDIR := $(shell mkdir -p $(DOWNLOAD))
 
@@ -461,7 +479,7 @@ $(BUILD)/binutils/_done: $(BUILD)/binutils/Makefile $(shell find 2>/dev/null $(P
 	$(L0)"install binutils"$(L1)$(MAKE) -C $(BUILD)/binutils install-gas install-binutils install-ld $(L2)
 	@echo "done" >$@
 
-$(BUILD)/binutils/Makefile: $(PROJECTS)/binutils/configure
+$(BUILD)/binutils/Makefile: $(PROJECTS)/binutils/configure | $(PREFIX_STAMP)
 	@mkdir -p $(BUILD)/binutils
 	$(L0)"configure binutils"$(L1) cd $(BUILD)/binutils && $(E) $(PROJECTS)/binutils/configure $(CONFIG_BINUTILS) $(L2)
 
@@ -535,7 +553,7 @@ $(BUILD)/gcc/_done: $(BUILD)/gcc/Makefile $(shell find 2>/dev/null $(GCCD) -maxd
 	$(L0)"install gcc"$(L1) $(MAKE) -C $(BUILD)/gcc install-gcc $(L2)
 	@echo "done" >$@
 
-$(BUILD)/gcc/Makefile: $(PROJECTS)/gcc/configure $(BUILD)/binutils/_done
+$(BUILD)/gcc/Makefile: $(PROJECTS)/gcc/configure $(BUILD)/binutils/_done | $(PREFIX_STAMP)
 	@mkdir -p $(BUILD)/gcc
 ifneq ($(OWNGMP),)
 	@mkdir -p $(PROJECTS)/gcc/gmp
@@ -930,7 +948,6 @@ LIBNIX_SRC = $(shell find 2>/dev/null $(PROJECTS)/libnix -not \( -path $(PROJECT
 libnix: $(BUILD)/libnix/_done
 
 $(BUILD)/libnix/_done: $(BUILD)/newlib/_done $(BUILD)/ndk-include_ndk $(BUILD)/ndk-include_ndk13 $(BUILD)/_netinclude $(BUILD)/binutils/_done $(BUILD)/gcc/_done $(PROJECTS)/libnix/Makefile.gcc6 $(LIBAMIGA) $(LIBNIX_SRC)
-#	@rsync -a --no-group --delete sys-include/ $(PREFIX)/$(TARGET)/sys-include
 	@mkdir -p $(PREFIX)/$(TARGET)/libnix/lib/libnix
 	@mkdir -p $(BUILD)/libnix
 	@mkdir -p $(PREFIX)/lib/gcc/$(TARGET)/$(GCC_VERSION)
@@ -1041,12 +1058,12 @@ $(BUILD)/newlib/_done: $(BUILD)/newlib/newlib/libc.a
 
 $(BUILD)/newlib/newlib/libc.a: $(BUILD)/newlib/newlib/Makefile $(BUILD)/binutils/_gdb $(NEWLIB_FILES)
 	@rsync -a --no-group $(PROJECTS)/newlib-cygwin/newlib/libc/include/ $(PREFIX)/$(TARGET)/sys-include
-	@rsync -a --no-group $(PROJECTS)/newlib-cygwin/newlib/libc/sys/amigaos/include/stabs.h $(PREFIX)/$(TARGET)/sys-include
+	@rsync -a --no-group $(PROJECTS)/newlib-cygwin/newlib/libc/sys/amigaos/include/ $(PREFIX)/$(TARGET)/sys-include
 	$(L0)"make newlib"$(L1) $(MAKE) -C $(BUILD)/newlib/newlib $(L2)
 	$(L0)"install newlib"$(L1) $(MAKE) -C $(BUILD)/newlib/newlib install $(L2)
 	@touch $@
 
-$(BUILD)/newlib/newlib/Makefile: $(PROJECTS)/newlib-cygwin/newlib/configure $(BUILD)/ndk-include_ndk $(BUILD)/gcc/_done
+$(BUILD)/newlib/newlib/Makefile: $(PROJECTS)/newlib-cygwin/newlib/configure $(BUILD)/ndk-include_ndk $(BUILD)/gcc/_done | $(PREFIX_STAMP)
 	@mkdir -p $(BUILD)/newlib/newlib
 	@if [ ! -f "$(BUILD)/newlib/newlib/Makefile" ]; then \
 	$(L00)"configure newlib"$(L1) cd $(BUILD)/newlib/newlib && $(NEWLIB_CONFIG) CFLAGS="$(CFLAGS_FOR_TARGET)" CC_FOR_BUILD="$(CC)" CXXFLAGS="$(CXXFLAGS_FOR_TARGET)" $(PROJECTS)/newlib-cygwin/newlib/configure --host=$(TARGET) --prefix=$(PREFIX) --enable-newlib-io-long-long --enable-newlib-io-c99-formats --enable-newlib-reent-small --enable-newlib-mb --enable-newlib-long-time_t $(L2) \


### PR DESCRIPTION
Two commits.

**build: keep sys-include complete and refuse a stale build tree.** Rebuilding into a changed or deleted prefix left sys-include with the raw newlib headers (only newlib's install step overlaid the amigaos port's patched ones), and libnix then failed to compile with `unknown type name '_mbstate_t'`. The newlib recipe now overlays the port headers in the same rsync step. The build tree also records the PREFIX it was configured for in `$(BUILD)/.prefix`, and make stops with a clear message when a later invocation uses a different PREFIX or the prefix directory no longer exists: the `_done` stamps only describe what was installed there. `make clean`, `update`, `info` and friends are exempt.

**workflow: build pull requests on demand with a label.** Label a pull request `ci` for a macOS build of its merge commit, or `ci-testsuite` for a Linux build with the gcc testsuite gate. workflow_dispatch cannot target fork branches, so this is the button we were missing. Remove and re-add the label to rerun.

This PR is its own first test: it carries the `ci` label.