### PR TITLE
Makefile: add the 68060 multilibs to MULTI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1233,11 +1233,14 @@ branch:
 # multilib support
 # =================================================
 MULTI = MODNAME/.: \
+		MODNAME/libm060:-m68060 \
 		MODNAME/libm020:-m68020 \
 		MODNAME/libm020/libm881:-m68020_-m68881 \
 		MODNAME/libb:-fbaserel \
+		MODNAME/libb/libm060:-fbaserel_-m68060 \
 		MODNAME/libb/libm020:-fbaserel_-m68020 \
 		MODNAME/libb/libm020/libm881:-fbaserel_-m68020_-m68881 \
+		MODNAME/libb32/libm060:-fbaserel32_-m68060 \
 		MODNAME/libb32/libm020:-fbaserel32_-m68020 \
 		MODNAME/libb32/libm020/libm881:-fbaserel32_-m68020_-m68881
 


### PR DESCRIPTION
gcc's t-amigaos builds libm060, libb/libm060 and libb32/libm060, but MULTI (the list driving MULTICONFIGURE/MULTIMAKE/INSTALL_MULTILIBS for zlib, libpng and freetype) never listed them, so those libraries are missing for -m68060 and links against them fail.

Adds the three entries, matching gcc's multilib set (no libm060/libm881: it is in MULTILIB_EXCEPTIONS).

Source: reinauer/container-amiga-gcc patches/amiga-gcc-zlib-68060.patch. Same change sent to bebbo as https://codeberg.org/bebbo/amiga-gcc/pulls/26.