### PR TITLE
build: update zlib to 1.3.2 and libpng to 1.6.58

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -103,6 +103,10 @@ jobs:
       - name: Build vbcc toolchain
         run: make -j $NPROC vbcc vlink MAKEINFO=true
 
+      # target libraries, one copy per multilib
+      - name: Build zlib and libpng
+        run: make -j $NPROC zlib libpng MAKEINFO=true
+
       # release tarballs are named after the tag (16.2-rc4), which
       # versions the whole distribution rather than just gcc
       - name: Package

--- a/Makefile
+++ b/Makefile
@@ -1276,8 +1276,8 @@ $(BUILD)/$(ZLIB)/_done: $(PREFIX)/$(TARGET)/lib/libz.a
 	@echo "done" >$@
 
 $(PREFIX)/$(TARGET)/lib/libz.a: $(BUILD)/$(ZLIB)/libz.a
-	@rsync -a --no-group $(PROJECTS)/$(ZLIB)/zlib.h $(PREFIX)/include/
-	@rsync -a --no-group $(BUILD)/$(ZLIB)/zconf.h $(PREFIX)/include/
+	@rsync -a --no-group $(PROJECTS)/$(ZLIB)/zlib.h $(PREFIX)/$(TARGET)/include/
+	@rsync -a --no-group $(BUILD)/$(ZLIB)/zconf.h $(PREFIX)/$(TARGET)/include/
 	$(call INSTALL_MULTILIBS,$(ZLIB),libz.a)
 	@touch $@
 
@@ -1314,9 +1314,9 @@ $(BUILD)/$(LIBPNG)/_done: $(PREFIX)/$(TARGET)/lib/libpng.a
 	@echo "done" >$@
 
 $(PREFIX)/$(TARGET)/lib/libpng.a: $(BUILD)/$(LIBPNG)/libpng.a
-	@rsync -a --no-group $(PROJECTS)/$(LIBPNG)/png.h $(PREFIX)/include/
-	@rsync -a --no-group $(PROJECTS)/$(LIBPNG)/pngconf.h $(PREFIX)/include/
-	@rsync -a --no-group $(BUILD)/$(LIBPNG)/pnglibconf.h $(PREFIX)/include/
+	@rsync -a --no-group $(PROJECTS)/$(LIBPNG)/png.h $(PREFIX)/$(TARGET)/include/
+	@rsync -a --no-group $(PROJECTS)/$(LIBPNG)/pngconf.h $(PREFIX)/$(TARGET)/include/
+	@rsync -a --no-group $(BUILD)/$(LIBPNG)/pnglibconf.h $(PREFIX)/$(TARGET)/include/
 	@$(call COPY_MULTILIBS,$(LIBPNG),.libs/libpng16.a,libpng.a)
 	$(call INSTALL_MULTILIBS,$(LIBPNG),libpng.a)
 	@touch $@
@@ -1352,8 +1352,8 @@ $(BUILD)/$(LIBFREETYPE)/_done: $(PREFIX)/$(TARGET)/lib/libfreetype.a
 	@echo "done" >$@
 
 $(PREFIX)/$(TARGET)/lib/libfreetype.a: $(BUILD)/$(LIBFREETYPE)/libfreetype.a
-	@rsync -a --no-group $(PROJECTS)/$(LIBFREETYPE)/include/ft2build.h $(PREFIX)/include/
-	@rsync -a --no-group $(PROJECTS)/$(LIBFREETYPE)/include/freetype $(PREFIX)/include/
+	@rsync -a --no-group $(PROJECTS)/$(LIBFREETYPE)/include/ft2build.h $(PREFIX)/$(TARGET)/include/
+	@rsync -a --no-group $(PROJECTS)/$(LIBFREETYPE)/include/freetype $(PREFIX)/$(TARGET)/include/
 	@$(call COPY_MULTILIBS,$(LIBFREETYPE),.libs/libfreetype.a,libfreetype.a)
 	$(call INSTALL_MULTILIBS,$(LIBFREETYPE),libfreetype.a)
 	@touch $@

--- a/Makefile
+++ b/Makefile
@@ -1282,7 +1282,7 @@ $(PREFIX)/$(TARGET)/lib/libz.a: $(BUILD)/$(ZLIB)/libz.a
 	@touch $@
 
 $(BUILD)/$(ZLIB)/libz.a: $(BUILD)/$(ZLIB)/Makefile
-	+$(call MULTIMAKE,$(ZLIB),libz.a)
+	+$(call MULTIMAKE,$(ZLIB),libz.a,AR=$(TARGET)-ar,ARFLAGS=rc)
 	@touch $@
 
 $(BUILD)/$(ZLIB)/Makefile: $(PROJECTS)/$(ZLIB)/configure

--- a/Makefile
+++ b/Makefile
@@ -1263,7 +1263,7 @@ MULTICONFIGURE = $(L0)"configure $1"$(L1) $(foreach T,$(subst MODNAME,$1,$(MULTI
 # =================================================
 # zlib
 # =================================================
-ZLIB=zlib-1.3.1
+ZLIB=zlib-1.3.2
 
 .PHONY: zlib clean-zlib
 
@@ -1287,6 +1287,8 @@ $(BUILD)/$(ZLIB)/libz.a: $(BUILD)/$(ZLIB)/Makefile
 
 $(BUILD)/$(ZLIB)/Makefile: $(PROJECTS)/$(ZLIB)/configure
 	$(call MULTICONFIGURE,$(ZLIB),libz.a,)
+	@# zlib 1.3.2 adds -fPIC unconditionally; the Amiga assembler has no GOT
+	@$(foreach T,$(subst MODNAME,$(ZLIB),$(MULTI)),$(SED) -i 's/ -fPIC//' $(BUILD)/$(word 1,$(subst :, ,${T}))/Makefile;)
 	@touch $@
 
 $(PROJECTS)/$(ZLIB)/configure: $(DOWNLOAD)/$(ZLIB).tar.gz
@@ -1294,12 +1296,12 @@ $(PROJECTS)/$(ZLIB)/configure: $(DOWNLOAD)/$(ZLIB).tar.gz
 	@touch $@
 
 $(DOWNLOAD)/$(ZLIB).tar.gz:
-	$(call get-file,zlib,https://zlib.net/fossils/$(ZLIB).tar.gz,$(ZLIB).tar.gz)
+	$(call get-file,zlib,https://zlib.net/fossils/$(ZLIB).tar.gz,$(ZLIB).tar.gz,bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16)
 
 # =================================================
 # libpng
 # =================================================
-LIBPNG=libpng-1.6.39
+LIBPNG=libpng-1.6.58
 
 .PHONY: libpng clean-libpng
 
@@ -1332,7 +1334,7 @@ $(PROJECTS)/$(LIBPNG)/configure: $(DOWNLOAD)/$(LIBPNG).tar.xz $(BUILD)/$(ZLIB)/_
 	@touch $@
 
 $(DOWNLOAD)/$(LIBPNG).tar.xz:
-	$(call get-file,libpng16,https://sourceforge.net/projects/libpng/files/libpng16/$(subst libpng-,,$(LIBPNG))/$(LIBPNG).tar.xz,$(LIBPNG).tar.xz)
+	$(call get-file,libpng16,https://sourceforge.net/projects/libpng/files/libpng16/$(subst libpng-,,$(LIBPNG))/$(LIBPNG).tar.xz,$(LIBPNG).tar.xz,28eb403f51f0f7405249132cecfe82ea5c0ef97f1b32c5a65828814ae0d34775)
 
 # =================================================
 # libfreetype


### PR DESCRIPTION
zlib 1.3.1 -> 1.3.2 and libpng 1.6.39 -> 1.6.58 (current upstream releases), with the tarball sha256 pinned through get-file.

zlib 1.3.2's configure adds -fPIC unconditionally ("CFLAGS=${CFLAGS--O3} -fPIC", after ours, so it cannot be overridden from CFLAGS and --static does not help). The Amiga assembler has no GOT, so every object failed with "syntax error -- statement move.l x@GOT(a4)". The rule now strips -fPIC from the generated Makefiles right after configure. On macOS zlib's configure also picks Apple's libtool as archiver, which cannot read m68k objects; AR/ARFLAGS are now passed to make.

The workflow builds both after the vbcc toolchain, so they are exercised in CI and ship in the release tarballs (one copy per multilib under m68k-amigaos/lib/), and the headers now install under m68k-amigaos/include like the NDK and SDK ones instead of $(PREFIX)/include.

Tested locally: both libraries build and install for all 11 multilibs; p96cts built against them (-lpng -lz) embeds libpng 1.6.58 and its PNG decode/capture tests pass on Amiberry. macOS CI (ci label) green on the previous push.