### PR TITLE
testsuite: commit dejagnu-site.exp

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -141,7 +141,6 @@ jobs:
       - name: Run the gcc testsuite
         if: env.RUN_TESTSUITE == 'true' && runner.os == 'Linux'
         run: |
-          echo "lappend boards_dir \"$PWD/baseboards\"" > dejagnu-site.exp
           env DEJAGNU=$PWD/dejagnu-site.exp PATH="$HOME/amitools-venv/bin:$PATH" \
             make -j $NPROC check MAKEINFO=true
 

--- a/README.md
+++ b/README.md
@@ -239,10 +239,9 @@ python3 -m venv .venv
 .venv/bin/pip install "amitools[vamos] @ git+https://github.com/AmigaPorts/amitools.git"
 ```
 
-Then point dejagnu at the board description in this repo and run the
-suite:
+Then run the suite with the site file from this repo, which points
+dejagnu at the board descriptions in `baseboards/`:
 ```
-echo "lappend boards_dir \"$PWD/baseboards\"" > dejagnu-site.exp
 DEJAGNU=$PWD/dejagnu-site.exp PATH="$PWD/.venv/bin:$PATH" make -j$(nproc) check
 ```
 

--- a/dejagnu-site.exp
+++ b/dejagnu-site.exp
@@ -1,0 +1,6 @@
+# Site file for running the gcc testsuite on the vamos boards in
+# baseboards/. Pass it as DEJAGNU=$PWD/dejagnu-site.exp; the path is
+# taken from this file's own location, so it works from any directory.
+set here [file dirname [file normalize [info script]]]
+lappend boards_dir [file join $here baseboards]
+unset here


### PR DESCRIPTION
The workflow and the README generated the dejagnu site file with an echo each time. This commits it instead, with boards_dir derived from the file's own location so it works from any directory (it is the same file the Makefile's check target and the CI step consume via DEJAGNU=$PWD/dejagnu-site.exp), and drops the echo from the workflow and the README.