### PR TITLE
NDK3.2: mark the custom chip and CIA registers volatile

### DIFF
--- a/patches/NDK3.2/Include_H/hardware/cia.h.diff
+++ b/patches/NDK3.2/Include_H/hardware/cia.h.diff
@@ -1,0 +1,56 @@
+--- old/hardware/cia.h
++++ new/hardware/cia.h
+@@ -26,37 +26,37 @@
+ 
+ 
+ struct CIA {
+-    UBYTE   ciapra;
++    volatile UBYTE   ciapra;
+     UBYTE   pad0[0xff];
+-    UBYTE   ciaprb;
++    volatile UBYTE   ciaprb;
+     UBYTE   pad1[0xff];
+-    UBYTE   ciaddra;
++    volatile UBYTE   ciaddra;
+     UBYTE   pad2[0xff];
+-    UBYTE   ciaddrb;
++    volatile UBYTE   ciaddrb;
+     UBYTE   pad3[0xff];
+-    UBYTE   ciatalo;
++    volatile UBYTE   ciatalo;
+     UBYTE   pad4[0xff];
+-    UBYTE   ciatahi;
++    volatile UBYTE   ciatahi;
+     UBYTE   pad5[0xff];
+-    UBYTE   ciatblo;
++    volatile UBYTE   ciatblo;
+     UBYTE   pad6[0xff];
+-    UBYTE   ciatbhi;
++    volatile UBYTE   ciatbhi;
+     UBYTE   pad7[0xff];
+-    UBYTE   ciatodlow;
++    volatile UBYTE   ciatodlow;
+     UBYTE   pad8[0xff];
+-    UBYTE   ciatodmid;
++    volatile UBYTE   ciatodmid;
+     UBYTE   pad9[0xff];
+-    UBYTE   ciatodhi;
++    volatile UBYTE   ciatodhi;
+     UBYTE   pad10[0xff];
+-    UBYTE   unusedreg;
++    volatile UBYTE   unusedreg;
+     UBYTE   pad11[0xff];
+-    UBYTE   ciasdr;
++    volatile UBYTE   ciasdr;
+     UBYTE   pad12[0xff];
+-    UBYTE   ciaicr;
++    volatile UBYTE   ciaicr;
+     UBYTE   pad13[0xff];
+-    UBYTE   ciacra;
++    volatile UBYTE   ciacra;
+     UBYTE   pad14[0xff];
+-    UBYTE   ciacrb;
++    volatile UBYTE   ciacrb;
+ };
+ 
+ 

--- a/patches/NDK3.2/Include_H/hardware/custom.h.diff
+++ b/patches/NDK3.2/Include_H/hardware/custom.h.diff
@@ -1,0 +1,237 @@
+--- old/hardware/custom.h
++++ new/hardware/custom.h
+@@ -22,122 +22,122 @@
+ 
+ 
+ struct Custom {
+-    UWORD   bltddat;
+-    UWORD   dmaconr;
+-    UWORD   vposr;
+-    UWORD   vhposr;
+-    UWORD   dskdatr;
+-    UWORD   joy0dat;
+-    UWORD   joy1dat;
+-    UWORD   clxdat;
+-    UWORD   adkconr;
+-    UWORD   pot0dat;
+-    UWORD   pot1dat;
+-    UWORD   potinp;
+-    UWORD   serdatr;
+-    UWORD   dskbytr;
+-    UWORD   intenar;
+-    UWORD   intreqr;
+-    APTR    dskpt;
+-    UWORD   dsklen;
+-    UWORD   dskdat;
+-    UWORD   refptr;
+-    UWORD   vposw;
+-    UWORD   vhposw;
+-    UWORD   copcon;
+-    UWORD   serdat;
+-    UWORD   serper;
+-    UWORD   potgo;
+-    UWORD   joytest;
+-    UWORD   strequ;
+-    UWORD   strvbl;
+-    UWORD   strhor;
+-    UWORD   strlong;
+-    UWORD   bltcon0;
+-    UWORD   bltcon1;
+-    UWORD   bltafwm;
+-    UWORD   bltalwm;
+-    APTR    bltcpt;
+-    APTR    bltbpt;
+-    APTR    bltapt;
+-    APTR    bltdpt;
+-    UWORD   bltsize;
+-    UBYTE   pad2d;
+-    UBYTE   bltcon0l;	/* low 8 bits of bltcon0, write only */
+-    UWORD   bltsizv;
+-    UWORD   bltsizh;	/* 5e */
+-    UWORD   bltcmod;
+-    UWORD   bltbmod;
+-    UWORD   bltamod;
+-    UWORD   bltdmod;
+-    UWORD   pad34[4];
+-    UWORD   bltcdat;
+-    UWORD   bltbdat;
+-    UWORD   bltadat;
+-    UWORD   pad3b[3];
+-    UWORD   deniseid;	/* 7c */
+-    UWORD   dsksync;
+-    ULONG   cop1lc;
+-    ULONG   cop2lc;
+-    UWORD   copjmp1;
+-    UWORD   copjmp2;
+-    UWORD   copins;
+-    UWORD   diwstrt;
+-    UWORD   diwstop;
+-    UWORD   ddfstrt;
+-    UWORD   ddfstop;
+-    UWORD   dmacon;
+-    UWORD   clxcon;
+-    UWORD   intena;
+-    UWORD   intreq;
+-    UWORD   adkcon;
++    volatile UWORD   bltddat;
++    volatile UWORD   dmaconr;
++    volatile UWORD   vposr;
++    volatile UWORD   vhposr;
++    volatile UWORD   dskdatr;
++    volatile UWORD   joy0dat;
++    volatile UWORD   joy1dat;
++    volatile UWORD   clxdat;
++    volatile UWORD   adkconr;
++    volatile UWORD   pot0dat;
++    volatile UWORD   pot1dat;
++    volatile UWORD   potinp;
++    volatile UWORD   serdatr;
++    volatile UWORD   dskbytr;
++    volatile UWORD   intenar;
++    volatile UWORD   intreqr;
++    volatile APTR    dskpt;
++    volatile UWORD   dsklen;
++    volatile UWORD   dskdat;
++    volatile UWORD   refptr;
++    volatile UWORD   vposw;
++    volatile UWORD   vhposw;
++    volatile UWORD   copcon;
++    volatile UWORD   serdat;
++    volatile UWORD   serper;
++    volatile UWORD   potgo;
++    volatile UWORD   joytest;
++    volatile UWORD   strequ;
++    volatile UWORD   strvbl;
++    volatile UWORD   strhor;
++    volatile UWORD   strlong;
++    volatile UWORD   bltcon0;
++    volatile UWORD   bltcon1;
++    volatile UWORD   bltafwm;
++    volatile UWORD   bltalwm;
++    volatile APTR    bltcpt;
++    volatile APTR    bltbpt;
++    volatile APTR    bltapt;
++    volatile APTR    bltdpt;
++    volatile UWORD   bltsize;
++    volatile UBYTE   pad2d;
++    volatile UBYTE   bltcon0l;	/* low 8 bits of bltcon0, write only */
++    volatile UWORD   bltsizv;
++    volatile UWORD   bltsizh;	/* 5e */
++    volatile UWORD   bltcmod;
++    volatile UWORD   bltbmod;
++    volatile UWORD   bltamod;
++    volatile UWORD   bltdmod;
++    volatile UWORD   pad34[4];
++    volatile UWORD   bltcdat;
++    volatile UWORD   bltbdat;
++    volatile UWORD   bltadat;
++    volatile UWORD   pad3b[3];
++    volatile UWORD   deniseid;	/* 7c */
++    volatile UWORD   dsksync;
++    volatile ULONG   cop1lc;
++    volatile ULONG   cop2lc;
++    volatile UWORD   copjmp1;
++    volatile UWORD   copjmp2;
++    volatile UWORD   copins;
++    volatile UWORD   diwstrt;
++    volatile UWORD   diwstop;
++    volatile UWORD   ddfstrt;
++    volatile UWORD   ddfstop;
++    volatile UWORD   dmacon;
++    volatile UWORD   clxcon;
++    volatile UWORD   intena;
++    volatile UWORD   intreq;
++    volatile UWORD   adkcon;
+     struct  AudChannel {
+-      UWORD *ac_ptr; /* ptr to start of waveform data */
+-      UWORD ac_len;	/* length of waveform in words */
+-      UWORD ac_per;	/* sample period */
+-      UWORD ac_vol;	/* volume */
+-      UWORD ac_dat;	/* sample pair */
+-      UWORD ac_pad[2];	/* unused */
++      UWORD * volatile ac_ptr; /* ptr to start of waveform data */
++      volatile UWORD ac_len;	/* length of waveform in words */
++      volatile UWORD ac_per;	/* sample period */
++      volatile UWORD ac_vol;	/* volume */
++      volatile UWORD ac_dat;	/* sample pair */
++      volatile UWORD ac_pad[2];	/* unused */
+     } aud[4];
+-    APTR    bplpt[8];
+-    UWORD   bplcon0;
+-    UWORD   bplcon1;
+-    UWORD   bplcon2;
+-    UWORD   bplcon3;
+-    UWORD   bpl1mod;
+-    UWORD   bpl2mod;
+-    UWORD   bplcon4;
+-    UWORD   clxcon2;
+-    UWORD   bpldat[8];
+-    APTR    sprpt[8];
++    volatile APTR    bplpt[8];
++    volatile UWORD   bplcon0;
++    volatile UWORD   bplcon1;
++    volatile UWORD   bplcon2;
++    volatile UWORD   bplcon3;
++    volatile UWORD   bpl1mod;
++    volatile UWORD   bpl2mod;
++    volatile UWORD   bplcon4;
++    volatile UWORD   clxcon2;
++    volatile UWORD   bpldat[8];
++    volatile APTR    sprpt[8];
+     struct  SpriteDef {
+-      UWORD pos;
+-      UWORD ctl;
+-      UWORD dataa;
+-      UWORD datab;
++      volatile UWORD pos;
++      volatile UWORD ctl;
++      volatile UWORD dataa;
++      volatile UWORD datab;
+     } spr[8];
+-    UWORD   color[32];
+-    UWORD htotal;
+-    UWORD hsstop;
+-    UWORD hbstrt;
+-    UWORD hbstop;
+-    UWORD vtotal;
+-    UWORD vsstop;
+-    UWORD vbstrt;
+-    UWORD vbstop;
+-    UWORD sprhstrt;
+-    UWORD sprhstop;
+-    UWORD bplhstrt;
+-    UWORD bplhstop;
+-    UWORD hhposw;
+-    UWORD hhposr;
+-    UWORD beamcon0;
+-    UWORD hsstrt;
+-    UWORD vsstrt;
+-    UWORD hcenter;
+-    UWORD diwhigh;	/* 1e4 */
+-    UWORD padf3[11];
+-    UWORD fmode;
++    volatile UWORD   color[32];
++    volatile UWORD htotal;
++    volatile UWORD hsstop;
++    volatile UWORD hbstrt;
++    volatile UWORD hbstop;
++    volatile UWORD vtotal;
++    volatile UWORD vsstop;
++    volatile UWORD vbstrt;
++    volatile UWORD vbstop;
++    volatile UWORD sprhstrt;
++    volatile UWORD sprhstop;
++    volatile UWORD bplhstrt;
++    volatile UWORD bplhstop;
++    volatile UWORD hhposw;
++    volatile UWORD hhposr;
++    volatile UWORD beamcon0;
++    volatile UWORD hsstrt;
++    volatile UWORD vsstrt;
++    volatile UWORD hcenter;
++    volatile UWORD diwhigh;	/* 1e4 */
++    volatile UWORD padf3[11];
++    volatile UWORD fmode;
+ };
+ 
+ #ifdef ECS_SPECIFIC


### PR DESCRIPTION
NDK 3.2's hardware/custom.h and hardware/cia.h have no volatile qualifiers, so a polling loop like `while (!(custom.vposr & 1));` is hoisted by gcc at -O1 and above. The NDK 3.9 tree in this repo has carried volatile patches for these two headers since 2018 (patches/NDK_3.9/Include/include_h/hardware/); this ports them to patches/NDK3.2/.

Differences from the 3.9 version:
- the anonymous struct/union wrapping vposr/vhposr (vpos32, vposr_h/_l) is left out: vbcc warns "struct/union member needs identifier" on it and gcc rejects it under -pedantic -std=c99. The two registers are plain volatile UWORD like the rest.
- `ac_ptr` is `UWORD * volatile`, i.e. the register field itself is volatile, rather than `volatile UWORD *` which only qualified the sample data it points at.

Tested by regenerating the diffs against the NDK 3.2 headers, applying them with the same `patch -N` the Makefile uses, and compiling a small polling/RMW test against the patched headers with gcc 16.2 (-O2 -Wall -Wextra -pedantic -std=c99, the vposr load stays inside the loop) and vbcc (-c99), both warning-free.