### PR TITLE
vbcc: point the aos68k config at the installed vbcc includes

### DIFF
--- a/patches/vbcc/aos68k.config
+++ b/patches/vbcc/aos68k.config
@@ -1,5 +1,5 @@
--cc=vbccm68k -quiet %s -o= %s %s -O=%ld -Ivincludeos3:
--ccv=vbccm68k %s -o= %s %s -O=%ld -Ivincludeos3:
+-cc=vbccm68k -quiet %s -o= %s %s -O=%ld -IPREFIX/m68k-amigaos/vbcc/include
+-ccv=vbccm68k %s -o= %s %s -O=%ld -IPREFIX/m68k-amigaos/vbcc/include
 -as=vasmm68k_mot -quiet -Fhunk -nowarn=62 %s -o %s
 -asv=vasmm68k_mot -Fhunk -nowarn=62 %s -o %s
 -rm=rm -f %s


### PR DESCRIPTION
patches/vbcc/aos68k.config still carried the stock `-Ivincludeos3:` assign, which does not exist on a cross host, so `vc +aos68k` fails on `#include <stdint.h>` from exec/types.h. aos68km and aos68kr already use `-IPREFIX/m68k-amigaos/vbcc/include`; do the same here.

This matches what container-amiga-gcc's install_vbcc_configs rewrites at install time, so the container can stop shipping its own copies of the configs once this is in.