### PR TITLE
workflow: add a repos input to build with module branches

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -17,6 +17,9 @@ on:
       runner:
         description: runner label (e.g. papert for self-hosted)
         default: ubuntu-24.04
+      repos:
+        description: "module overrides, space separated: sfdc=branch or sfdc=URL#branch"
+        default: ""
   # same inputs again: workflow_call, used by release.yml, does not
   # share the workflow_dispatch input declarations
   workflow_call:
@@ -33,6 +36,9 @@ on:
       runner:
         type: string
         default: ubuntu-24.04
+      repos:
+        type: string
+        default: ""
   # label a pull request "ci" for a macOS build of its merge commit, or
   # "ci-testsuite" for a Linux build with the gcc testsuite
   pull_request:
@@ -88,6 +94,25 @@ jobs:
 
       - name: Select gcc branch
         run: make branch branch=amiga$GCC_VER mod=gcc
+
+      # build with a pull request from another module's repo: each
+      # word is module=branch, or module=URL#branch for a fork
+      - name: Override module repos
+        if: inputs.repos != ''
+        env:
+          REPOS: ${{ inputs.repos }}
+        run: |
+          for spec in $REPOS; do
+            mod=${spec%%=*}
+            ref=${spec#*=}
+            grep -q "^$mod[[:blank:]]" .repos || { echo "unknown module: $mod"; exit 1; }
+            if [[ "$ref" == *"#"* ]]; then
+              sed -i "s|^$mod[[:blank:]].*|$mod ${ref%%#*} ${ref##*#}|" .repos
+            else
+              make branch mod=$mod branch=$ref
+            fi
+          done
+          cat .repos
 
       - name: Fetch sources
         run: make update

--- a/README.md
+++ b/README.md
@@ -200,6 +200,18 @@ bootstraps the toolchain from scratch, optionally runs the gcc
 testsuite under vamos, and uploads the packaged tarball as a build
 artifact. It can be dispatched manually against any gcc branch.
 
+To test a change to one of the module repositories (sfdc, binutils,
+libnix, ...) before it is merged, dispatch the workflow with the
+`repos` input set to the module and branch, or `URL#branch` for a
+fork; several overrides are separated by spaces:
+
+```
+gh workflow run toolchain.yml --repo AmigaPorts/m68k-amigaos-gcc \
+    -f repos="sfdc=fix-nolibbase-tag-wrappers binutils=https://github.com/user/binutils-gdb#my-fix"
+```
+
+The module names are the first column of `.repos`.
+
 Pushing a tag matching `v*` additionally publishes the tarball as a
 GitHub release, with the gcc testsuite as a release gate.
 


### PR DESCRIPTION
Module changes (sfdc, binutils, libnix, ...) could only be tested by the toolchain CI after they were merged, which is how the sfdc __NOLIBBASE__ regression got through. This adds a `repos` input to the workflow (dispatch and call): space separated `module=branch`, or `module=URL#branch` for a fork, applied to .repos before `make update`, so the clone rules pick up the override. Module names are the first column of .repos; unknown names fail the step. README documents the `gh workflow run ... -f repos=...` invocation.

Test run on this branch, building with an sfdc branch from a fork: https://github.com/AmigaPorts/m68k-amigaos-gcc/actions/runs/33046756213 (repos=sfdc=https://codeberg.org/codewiz/sfdc#fix/extend-narrow-register-args).