### PR TITLE
gcc: configure --without-zstd for reproducible LTO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -527,7 +527,7 @@ $(BUILD)/binutils/gprof/Makefile: $(PROJECTS)/binutils/configure $(BUILD)/binuti
 # =================================================
 # gcc
 # =================================================
-CONFIG_GCC = --prefix=$(PREFIX) --target=$(TARGET) --enable-languages=c,c++,objc,$(ADDLANG) --enable-version-specific-runtime-libs --disable-libssp --disable-nls \
+CONFIG_GCC = --prefix=$(PREFIX) --target=$(TARGET) --enable-languages=c,c++,objc,$(ADDLANG) --enable-version-specific-runtime-libs --disable-libssp --disable-nls --without-zstd \
 	--with-headers=$(PROJECTS)/newlib-cygwin/newlib/libc/sys/amigaos/include/ --disable-shared --enable-threads=$(THREADS) \
 	--with-stage1-ldflags="-dynamic-libgcc -dynamic-libstdc++" --with-boot-ldflags="-dynamic-libgcc -dynamic-libstdc++"
 


### PR DESCRIPTION
GCC auto-detects `libzstd` at configure time and, when present, uses it as the LTO bytecode compression codec. `CONFIG_GCC` passes neither `--with-zstd` nor `--without-zstd`, so which codec we get depends on what happens to be installed on the build host.

That bites in two ways:

- **Mismatch.** A runner with `libzstd-dev` produces a gcc whose `cc1` writes zstd-compressed LTO sections; a host without it produces a zlib-only `lto1`. Feed the former's objects to the latter and the link dies with:
  ```
  lto1: fatal error: compiler does not support ZSTD LTO compression
  ```
- **Runtime dependency.** A zstd-enabled relocatable tarball links `libzstd.so.1`, which the end user's machine may not have.

The codec only affects the size and speed of the LTO intermediates inside `.o` files -- never the generated m68k code or correctness. Pinning `--without-zstd` makes LTO always use zlib, so the toolchain is reproducible across build hosts and self-contained.