### PR TITLE
check: run the m68k-amigaos target testsuite under vamos

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -52,7 +52,7 @@ on:
       hosted_gcc_branch:
         type: string
         default: amiga16.2
-  # label a pull request "ci" for a macOS build of its merge commit,
+  # label a pull request "ci-macos" for a macOS build of its merge commit,
   # "ci-testsuite" for a Linux build with the gcc testsuite, or "ci-cross"
   # for Linux plus the AmigaOS and MinGW hosted toolchains
   pull_request:
@@ -61,7 +61,7 @@ on:
 jobs:
   build:
     if: github.event_name != 'pull_request' || startsWith(github.event.label.name, 'ci')
-    runs-on: ${{ inputs.runner || (github.event.label.name == 'ci' && 'macos-15') || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.runner || (github.event.label.name == 'ci-macos' && 'macos-15') || 'ubuntu-24.04' }}
     timeout-minutes: 300
     env:
       RUN_TESTSUITE: ${{ inputs.run_testsuite || github.event.label.name == 'ci-testsuite' }}

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -184,18 +184,11 @@ jobs:
       - name: Run the gcc testsuite
         if: env.RUN_TESTSUITE == 'true' && runner.os == 'Linux'
         run: |
-          env DEJAGNU=$PWD/dejagnu-site.exp PATH="$HOME/amitools-venv/bin:$PATH" \
-            make -j $NPROC check MAKEINFO=true
-
-      - name: Testsuite summary
-        if: always() && env.RUN_TESTSUITE == 'true' && runner.os == 'Linux'
-        run: |
-          sum=$(ls build-*/gcc/gcc/testsuite/gcc/gcc.sum) || exit 0
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          grep -A6 "=== gcc Summary ===" "$sum" >> $GITHUB_STEP_SUMMARY
-          echo >> $GITHUB_STEP_SUMMARY
-          grep "^FAIL\|^ERROR" "$sum" >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+          set +e
+          PATH="$HOME/amitools-venv/bin:$PATH" make -j $NPROC check
+          rc=$?
+          { echo '```'; cat check-gcc-execute.summary.txt check-gcc-amigaos.summary.txt 2>/dev/null; echo '```'; } >> $GITHUB_STEP_SUMMARY
+          exit $rc
 
       - name: Upload testsuite results
         if: always() && env.RUN_TESTSUITE == 'true' && runner.os == 'Linux'
@@ -203,8 +196,10 @@ jobs:
         with:
           name: testsuite-results
           path: |
-            build-*/gcc/gcc/testsuite/gcc/gcc.sum
-            build-*/gcc/gcc/testsuite/gcc/gcc.log
+            build-*/gcc/gcc/testsuite/gcc/gcc-execute.sum
+            build-*/gcc/gcc/testsuite/gcc/gcc-execute.log
+            build-*/gcc/gcc/testsuite/gcc/gcc-amigaos.sum
+            build-*/gcc/gcc/testsuite/gcc/gcc-amigaos.log
           if-no-files-found: ignore
 
   build_amigaos:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ projects
 download
 Output
 *.log
+*.summary.txt
 .lock
 .state
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -1583,8 +1583,7 @@ endif
 
 # Point dejagnu at the in-repo board descriptions in baseboards/ which wire up
 # vamos as the simulator.
-export DEJAGNU ?= $(shell pwd)/dejagnu-site.exp
-
+export DEJAGNU ?= $(CURDIR)/dejagnu-site.exp
 # Directory where dejagnu writes gcc.sum / gcc.log.
 TESTSUITE = $(BUILD)/gcc/gcc/testsuite/gcc
 

--- a/Makefile
+++ b/Makefile
@@ -1592,8 +1592,8 @@ TESTSUITE = $(BUILD)/gcc/gcc/testsuite/gcc
 # drive check-gcc-c in the same build tree, sharing gcc.sum and
 # testsuite/gcc-parallel, so they must not run at the same time.
 check:
-	@$(MAKE) --no-print-directory check-gcc-execute
 	@$(MAKE) --no-print-directory check-gcc-amigaos
+	@$(MAKE) --no-print-directory check-gcc-execute
 
 check-gcc-execute:
 	@ln -sf $(PREFIX)/$(TARGET)/libnix $(BUILD)/gcc/$(TARGET)/libnix

--- a/Makefile
+++ b/Makefile
@@ -1599,7 +1599,7 @@ check-gcc-execute:
 	@ln -sf $(PREFIX)/$(TARGET)/libnix $(BUILD)/gcc/$(TARGET)/libnix
 	$(L0)"check execute.exp"$(L1)$(MAKE) -C $(BUILD)/gcc check-gcc-c "RUNTESTFLAGS=--target_board=$(board) execute.exp=* SIM=vamos"$(L2)
 	@cp -f $(TESTSUITE)/gcc.sum $(TESTSUITE)/gcc-execute.sum; cp -f $(TESTSUITE)/gcc.log $(TESTSUITE)/gcc-execute.log
-	@{ echo '----- execute.exp -----'; grep '^# of' $(TESTSUITE)/gcc-execute.sum || echo '(no tests run)'; grep '^FAIL\|^ERROR\|^XPASS' $(TESTSUITE)/gcc-execute.sum || true; } | tee $@.summary.txt
+@{ echo '----- execute.exp -----'; grep '^# of' $(TESTSUITE)/gcc-execute.sum || echo '(no tests run)'; grep -E '^(FAIL|ERROR|XPASS)' $(TESTSUITE)/gcc-execute.sum || true; } | tee $@.summary.txt
 
 # amiga-specific target tests; a no-op on gcc branches that predate them (a .exp filter matching no file runs nothing).
 check-gcc-amigaos:

--- a/Makefile
+++ b/Makefile
@@ -1599,14 +1599,14 @@ check-gcc-execute:
 	@ln -sf $(PREFIX)/$(TARGET)/libnix $(BUILD)/gcc/$(TARGET)/libnix
 	$(L0)"check execute.exp"$(L1)$(MAKE) -C $(BUILD)/gcc check-gcc-c "RUNTESTFLAGS=--target_board=$(board) execute.exp=* SIM=vamos"$(L2)
 	@cp -f $(TESTSUITE)/gcc.sum $(TESTSUITE)/gcc-execute.sum; cp -f $(TESTSUITE)/gcc.log $(TESTSUITE)/gcc-execute.log
-@{ echo '----- execute.exp -----'; grep '^# of' $(TESTSUITE)/gcc-execute.sum || echo '(no tests run)'; grep -E '^(FAIL|ERROR|XPASS)' $(TESTSUITE)/gcc-execute.sum || true; } | tee $@.summary.txt
+	@{ echo '----- execute.exp -----'; grep '^# of' $(TESTSUITE)/gcc-execute.sum || echo '(no tests run)'; grep -E '^(FAIL|ERROR|XPASS)' $(TESTSUITE)/gcc-execute.sum || true; } | tee $@.summary.txt
 
 # amiga-specific target tests; a no-op on gcc branches that predate them (a .exp filter matching no file runs nothing).
 check-gcc-amigaos:
 	@ln -sf $(PREFIX)/$(TARGET)/libnix $(BUILD)/gcc/$(TARGET)/libnix
 	$(L0)"check amigaos.exp"$(L1)$(MAKE) -C $(BUILD)/gcc check-gcc-c "RUNTESTFLAGS=--target_board=$(board) gcc.target/m68k/amigaos/amigaos.exp SIM=vamos"$(L2)
 	@cp -f $(TESTSUITE)/gcc.sum $(TESTSUITE)/gcc-amigaos.sum; cp -f $(TESTSUITE)/gcc.log $(TESTSUITE)/gcc-amigaos.log
-	@{ echo '----- amigaos.exp -----'; grep '^# of' $(TESTSUITE)/gcc-amigaos.sum || echo '(no tests run)'; grep '^FAIL\|^ERROR\|^XPASS' $(TESTSUITE)/gcc-amigaos.sum || true; } | tee $@.summary.txt
+	@{ echo '----- amigaos.exp -----'; grep '^# of' $(TESTSUITE)/gcc-amigaos.sum || echo '(no tests run)'; grep -E '^(FAIL|ERROR|XPASS)' $(TESTSUITE)/gcc-amigaos.sum || true; } | tee $@.summary.txt
 
 
 # =================================================

--- a/Makefile
+++ b/Makefile
@@ -1581,10 +1581,33 @@ ifeq (,$(board))
 board = amigaos
 endif
 
-.PHONY: check
+# Point dejagnu at the in-repo board descriptions in baseboards/ which wire up
+# vamos as the simulator.
+export DEJAGNU ?= $(shell pwd)/dejagnu-site.exp
+
+# Directory where dejagnu writes gcc.sum / gcc.log.
+TESTSUITE = $(BUILD)/gcc/gcc/testsuite/gcc
+
+.PHONY: check check-gcc-execute check-gcc-amigaos
+# Run the two sequentially (recipe lines run in order even under make -j): both
+# drive check-gcc-c in the same build tree, sharing gcc.sum and
+# testsuite/gcc-parallel, so they must not run at the same time.
 check:
+	@$(MAKE) --no-print-directory check-gcc-execute
+	@$(MAKE) --no-print-directory check-gcc-amigaos
+
+check-gcc-execute:
 	@ln -sf $(PREFIX)/$(TARGET)/libnix $(BUILD)/gcc/$(TARGET)/libnix
-	$(MAKE) -C $(BUILD)/gcc check-gcc-c "RUNTESTFLAGS=--target_board=$(board) execute.exp=* SIM=vamos" | grep '# of\|PASS\|FAIL\|===\|Running\|Using' 
+	$(L0)"check execute.exp"$(L1)$(MAKE) -C $(BUILD)/gcc check-gcc-c "RUNTESTFLAGS=--target_board=$(board) execute.exp=* SIM=vamos"$(L2)
+	@cp -f $(TESTSUITE)/gcc.sum $(TESTSUITE)/gcc-execute.sum; cp -f $(TESTSUITE)/gcc.log $(TESTSUITE)/gcc-execute.log
+	@{ echo '----- execute.exp -----'; grep '^# of' $(TESTSUITE)/gcc-execute.sum || echo '(no tests run)'; grep '^FAIL\|^ERROR\|^XPASS' $(TESTSUITE)/gcc-execute.sum || true; } | tee $@.summary.txt
+
+# amiga-specific target tests; a no-op on gcc branches that predate them (a .exp filter matching no file runs nothing).
+check-gcc-amigaos:
+	@ln -sf $(PREFIX)/$(TARGET)/libnix $(BUILD)/gcc/$(TARGET)/libnix
+	$(L0)"check amigaos.exp"$(L1)$(MAKE) -C $(BUILD)/gcc check-gcc-c "RUNTESTFLAGS=--target_board=$(board) gcc.target/m68k/amigaos/amigaos.exp SIM=vamos"$(L2)
+	@cp -f $(TESTSUITE)/gcc.sum $(TESTSUITE)/gcc-amigaos.sum; cp -f $(TESTSUITE)/gcc.log $(TESTSUITE)/gcc-amigaos.log
+	@{ echo '----- amigaos.exp -----'; grep '^# of' $(TESTSUITE)/gcc-amigaos.sum || echo '(no tests run)'; grep '^FAIL\|^ERROR\|^XPASS' $(TESTSUITE)/gcc-amigaos.sum || true; } | tee $@.summary.txt
 
 
 # =================================================

--- a/README.md
+++ b/README.md
@@ -248,23 +248,23 @@ You can select one of the various runtimes. My favorite is `libnix` which is sel
 ## Checking gcc
 
 To check the built toolchain, run the gcc dejagnu execution tests.
+
 This does not cover everything but it's a start. The tests run each
-compiled testcase under vamos (from
-https://github.com/AmigaPorts/amitools) to emulate the AmigaOS APIs,
-so `vamos` must be on the PATH.
+compiled testcase under [vamos](https://github.com/AmigaPorts/amitools)
+to emulate the AmigaOS APIs, so `vamos` must be on the PATH.
 
 Install dejagnu (`sudo apt install dejagnu` on Debian/Ubuntu,
 `brew install dejagnu` on macOS) and amitools, in a venv to keep it
 out of the system Python:
-```
+```shell
 python3 -m venv .venv
 .venv/bin/pip install "amitools[vamos] @ git+https://github.com/AmigaPorts/amitools.git"
+source .venv/bin/activate
 ```
 
-Then run the suite with the site file from this repo, which points
-dejagnu at the board descriptions in `baseboards/`:
-```
-DEJAGNU=$PWD/dejagnu-site.exp PATH="$PWD/.venv/bin:$PATH" make -j$(nproc) check
+Then run the testsuite:
+```shell
+make -j$(nproc) check
 ```
 
 ## Version management


### PR DESCRIPTION
Wires the new `gcc.target/m68k/amigaos/` testsuite (AmigaPorts/gcc#27) into
CI.

`make check` previously ran only `execute.exp`. Split it into
`check-gcc-execute` and `check-gcc-amigaos` (the aggregate runs both,
sequentially -- they share the build's `gcc.sum`, so they must not run at the
same time under `make -j`). The amiga tests run in a separate `runtest`
invocation because dejagnu drops an earlier `foo.exp=pattern` when a second
`.exp` is listed; each run rewrites `gcc.sum`, so each target keeps its own
`gcc-*.sum` / `gcc-*.log`.

On gcc branches that predate the tests `check-gcc-amigaos` is a no-op (a `.exp`
filter matching no file just runs nothing), so this is safe to merge ahead of
the gcc change.

Also:

- `DEJAGNU` now defaults to `baseboards/` in the Makefile (overridable), so the
  workflow and README no longer set it.
- Each check target writes a clean, ANSI-free summary to both stdout and
  `<target>.summary.txt`; the workflow appends those to `$GITHUB_STEP_SUMMARY`,
  which replaces the separate summary step. The noisy runtest output goes to
  `log/` via the usual logging idiom.
