### PR TITLE
baseboards: raise vamos RAM to 11 MiB so large-BSS tests run

### DIFF
--- a/baseboards/amigaos-020-baserel.exp
+++ b/baseboards/amigaos-020-baserel.exp
@@ -20,7 +20,7 @@ set_board_info ldflags "-lpthread"
 set_board_info ldscript "";
 
 set_board_info sim vamos
-set_board_info sim,options "-C 68020 -s 4096 -m 8192"
+set_board_info sim,options "-C 68020 -s 4096 -m 11264"
 set_board_info gcc,stack_size 4096
 set_board_info isremote 0
 set_board_info slow_simulator 0

--- a/baseboards/amigaos-020-baserel32.exp
+++ b/baseboards/amigaos-020-baserel32.exp
@@ -20,7 +20,7 @@ set_board_info ldflags "-lpthread"
 set_board_info ldscript "";
 
 set_board_info sim vamos
-set_board_info sim,options "-C 68020 -s 4096 -m 8192"
+set_board_info sim,options "-C 68020 -s 4096 -m 11264"
 set_board_info gcc,stack_size 4096
 set_board_info isremote 0
 set_board_info slow_simulator 0

--- a/baseboards/amigaos-020.exp
+++ b/baseboards/amigaos-020.exp
@@ -20,7 +20,7 @@ set_board_info ldflags "-lpthread"
 set_board_info ldscript "";
 
 set_board_info sim vamos
-set_board_info sim,options "-C 68020 -s 4096 -m 8192"
+set_board_info sim,options "-C 68020 -s 4096 -m 11264"
 set_board_info gcc,stack_size 4096
 set_board_info isremote 0
 set_board_info slow_simulator 0

--- a/baseboards/amigaos-baserel.exp
+++ b/baseboards/amigaos-baserel.exp
@@ -20,7 +20,7 @@ set_board_info ldflags "-lpthread"
 set_board_info ldscript "";
 
 set_board_info sim vamos
-set_board_info sim,options "-C 68020 -s 4096 -m 8192"
+set_board_info sim,options "-C 68020 -s 4096 -m 11264"
 set_board_info gcc,stack_size 4096
 set_board_info isremote 0
 set_board_info slow_simulator 0

--- a/baseboards/amigaos.exp
+++ b/baseboards/amigaos.exp
@@ -20,7 +20,7 @@ set_board_info ldflags "-lpthread"
 set_board_info ldscript "";
 
 set_board_info sim vamos
-set_board_info sim,options "-C 68020 -s 4096 -m 8192"
+set_board_info sim,options "-C 68020 -s 4096 -m 11264"
 set_board_info gcc,stack_size 4096
 set_board_info isremote 0
 set_board_info slow_simulator 0


### PR DESCRIPTION
The vamos boards ran with `-m 8192` (8 MiB). `g++.dg/init/array15.C` and
`array16.C` carry a ~5 MB static array; together with the 4 MiB stack
(`-s 4096`) that exceeds 8 MiB, the guest `AllocMem` fails, and vamos aborts
with a fatal `VamosInternalError` instead of returning NULL:

```
mem_alloc: ERROR: [alloc: NO MEMORY for 400000 bytes]
amitools.vamos.error.VamosInternalError: Internal Vamos Error: [alloc: NO MEMORY for 400000 bytes]
FAIL: g++.dg/init/array15.C  -std=c++20 execution test
```

Raise the pool to 11 MiB (`-m 11264`) across the vamos boards. Verified:
`array15.exe` and `array16.exe` both run to exit 0 at `-m 11264`. 11 MiB stays
under the ~12 MiB ceiling the 68020 hw-access memory map imposes (`-m 12288`
trips "Too much RAM allocated with hw access enabled").

Addresses the vamos-crash bucket in #57. (The separate vamos robustness fix --
return NULL on guest OOM rather than abort -- belongs in amitools.)