### PR TITLE
workflow: use GitHub release notes, keep commits collapsed

### DIFF
--- a/.github/scripts/gen-release-notes.sh
+++ b/.github/scripts/gen-release-notes.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Print the release notes for a tag: the tag message body, GitHub's
+# "What's Changed" PR list as "- summary (#nn by @author)", and the
+# full commit list collapsed (direct pushes never appear as PRs).
+# Usage: gen-release-notes.sh <tag> [owner/repo]
+set -euo pipefail
+
+TAG=$1
+REPO=${2:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}
+# --exclude, so the previous tag is found even when the tag is on a merge
+PREV=$(git describe --tags --abbrev=0 --match='v*' --exclude="$TAG" "$TAG" 2>/dev/null || true)
+
+BODY=$(git tag -l --format='%(contents:body)' "$TAG")
+test -z "$BODY" || printf '%s\n\n' "$BODY"
+
+gh api "repos/$REPO/releases/generate-notes" -f tag_name="$TAG" \
+    ${PREV:+-f previous_tag_name="$PREV"} -q .body \
+  | sed -E 's|^\* (.*) by @([A-Za-z0-9-]+) in https://[^ ]+/pull/([0-9]+)\r?$|- \1 (#\3 by @\2)|'
+
+printf '\n<details><summary>All commits</summary>\n\n'
+git log --pretty=format:'- %h: %s' ${PREV:+$PREV..}$TAG
+printf '\n\n</details>\n'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,16 +56,28 @@ jobs:
           # as workflow syntax the way a $GITHUB_OUTPUT heredoc can.
           #
           # The tag's message body, if it has one, becomes the prose at the top
-          # of the release; write it with "git tag -a -e". A tag with only a
-          # subject line leaves just the commit list.
+          # of the release; write it with "git tag -a -e". --generate-notes
+          # appends the GitHub "What's Changed" section listing the pull
+          # requests merged since the previous tag; commits pushed directly
+          # to a branch do not appear there, so the full commit list is kept
+          # in a collapsed section below it.
           {
             NOTES=$(git tag -l --format='%(contents:body)' "$TAG")
             if [ -n "$NOTES" ]; then
               printf '%s\n\n' "$NOTES"
             fi
-            echo "## Changes"
-            echo
-            git log --pretty=format:"- %h: %s" "$RANGE"
           } > notes.md
           gh release create "$TAG" m68k-amigaos-gcc-* \
-            --title "Release ${TAG#v}" --notes-file notes.md
+            --title "Release ${TAG#v}" --notes-file notes.md --generate-notes
+          {
+            echo
+            echo "<details><summary>All commits</summary>"
+            echo
+            git log --pretty=format:"- %h: %s" "$RANGE"
+            echo
+            echo
+            echo "</details>"
+          } > commits.md
+          gh release view "$TAG" --json body -q .body > body.md
+          cat body.md commits.md > full.md
+          gh release edit "$TAG" --notes-file full.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,44 +43,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
-          # search from the tag itself, excluding it: "$TAG^" would only
-          # walk the first-parent lineage and miss the previous tag when
-          # the release commit is a merge
-          PREV_TAG=$(git describe --tags --abbrev=0 --match='v*' --exclude="$TAG" "$TAG" 2>/dev/null || true)
-          if [ -n "$PREV_TAG" ]; then
-            RANGE="$PREV_TAG..$TAG"
-          else
-            RANGE="$TAG"
-          fi
-          # --notes-file, so a tag message or commit subject can never be read
-          # as workflow syntax the way a $GITHUB_OUTPUT heredoc can.
-          #
-          # The tag's message body, if it has one, becomes the prose at the top
-          # of the release; write it with "git tag -a -e". --generate-notes
-          # appends the GitHub "What's Changed" section listing the pull
-          # requests merged since the previous tag; commits pushed directly
-          # to a branch do not appear there, so the full commit list is kept
-          # in a collapsed section below it.
-          {
-            NOTES=$(git tag -l --format='%(contents:body)' "$TAG")
-            if [ -n "$NOTES" ]; then
-              printf '%s\n\n' "$NOTES"
-            fi
-          } > notes.md
+          # The tag's message body becomes the prose at the top of the
+          # release; write it with "git tag -a -e". The script appends the
+          # "What's Changed" PR list and the collapsed commit list, and can
+          # be run locally to preview the notes before pushing a tag.
+          # --notes-file, so a tag message or commit subject can never be
+          # read as workflow syntax the way a $GITHUB_OUTPUT heredoc can.
+          .github/scripts/gen-release-notes.sh "$TAG" > notes.md
           gh release create "$TAG" m68k-amigaos-gcc-* \
-            --title "Release ${TAG#v}" --notes-file notes.md --generate-notes
-          {
-            echo
-            echo "<details><summary>All commits</summary>"
-            echo
-            git log --pretty=format:"- %h: %s" "$RANGE"
-            echo
-            echo
-            echo "</details>"
-          } > commits.md
-          gh release view "$TAG" --json body -q .body > body.md
-          # Reformat the generated PR bullets to the house style: "- Change summary (#nn by @author)"
-          sed -E 's|^\* (.*) by @([A-Za-z0-9-]+) in https://github\.com/[^ ]+/pull/([0-9]+)\r?$|- \1 (#\3 by @\2)|' \
-            body.md > body-fmt.md
-          cat body-fmt.md commits.md > full.md
-          gh release edit "$TAG" --notes-file full.md
+            --title "Release ${TAG#v}" --notes-file notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,5 +79,8 @@ jobs:
             echo "</details>"
           } > commits.md
           gh release view "$TAG" --json body -q .body > body.md
-          cat body.md commits.md > full.md
+          # Reformat the generated PR bullets to the house style: "- Change summary (#nn by @author)"
+          sed -E 's|^\* (.*) by @([A-Za-z0-9-]+) in https://github\.com/[^ ]+/pull/([0-9]+)\r?$|- \1 (#\3 by @\2)|' \
+            body.md > body-fmt.md
+          cat body-fmt.md commits.md > full.md
           gh release edit "$TAG" --notes-file full.md


### PR DESCRIPTION
Adopts GitHub's auto-generated release notes (the "What's Changed" PR list, as seen on Amiberry releases) while keeping our hand-written tag-body prose on top and the complete commit list in a collapsed details section, since commits pushed directly to branches never appear in the generated PR list.

Release body layout becomes:

1. tag message body (hand-written notes, unchanged)
2. What's Changed: one bullet per merged PR with author and link, plus the Full Changelog compare link
3. All commits (collapsed): the same git log list we publish today

Note for the first release after merging: the What's Changed section will one-time list some old "Fetch upstream" PRs whose merge commits became newly reachable from a release tag via the gcc10 merge; they can be deleted by editing the release body, and later releases only list genuinely new PRs. The published body is never rewritten by CI, so hand-curating it after publication (Amiberry 8.2.0 style) is safe.