### PR TITLE
binutils: enable the m68k-elf extra target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -762,7 +762,7 @@ update-mpc:
 CONFIG_BINUTILS = --prefix=$(PREFIX) --target=$(TARGET) $(HOST_CONFIGURE) --disable-werror --disable-nls --without-msgpack
 
 ifeq (,$(strip $(HOST)))
-CONFIG_BINUTILS += --enable-tui
+CONFIG_BINUTILS += --enable-tui --enable-targets=m68k-elf
 else
 CONFIG_BINUTILS += --disable-gdb --disable-gdbserver
 ifneq (,$(findstring mingw,$(HOST)))


### PR DESCRIPTION
Configures binutils with --enable-targets=m68k-elf: BFD gains the elf32-m68k vector and ld the m68kelf emulation, so objdump, objcopy, nm and ld can read, convert and link m68k ELF objects alongside hunk.

Verified with a full local binutils build and an end-to-end round trip: a hunk object converted with objcopy -O elf32-m68k is a valid ELF relocatable, objdump -d disassembles it, and ld -m m68kelf links it into an ELF executable. gas is unaffected and still emits hunk only.

Depends on AmigaPorts/binutils-gdb#12: without it the build breaks in two ways (the m68kelfamiga emulation sources did not compile since 2.38, and gas pulled ELF object attributes into the hunk-only assembler).