### PR TITLE
build: make gdb's ncurses TUI dependency optional

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -111,7 +111,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             autoconf automake bison build-essential ca-certificates flex \
-            gettext git libgmp-dev libmpfr-dev libmpc-dev libncurses-dev \
+            gettext git libgmp-dev libmpfr-dev libmpc-dev \
             rsync wget xz-utils
 
       # Apple ships old or BSD versions of most build tools; put the brew

--- a/Makefile
+++ b/Makefile
@@ -762,7 +762,7 @@ update-mpc:
 CONFIG_BINUTILS = --prefix=$(PREFIX) --target=$(TARGET) $(HOST_CONFIGURE) --disable-werror --disable-nls --without-msgpack
 
 ifeq (,$(strip $(HOST)))
-CONFIG_BINUTILS += --enable-tui --enable-targets=m68k-elf
+CONFIG_BINUTILS += --enable-targets=m68k-elf
 else
 CONFIG_BINUTILS += --disable-gdb --disable-gdbserver
 ifneq (,$(findstring mingw,$(HOST)))

--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ AmigaOS-specific changes are maintained in the upstream AmigaPorts repositories.
 ## Prerequisites
 ### Fedora
 ```
-sudo dnf install wget gcc gcc-c++ python git perl-Pod-Simple gperf patch autoconf automake make makedepend bison flex ncurses-devel gmp-devel mpfr-devel libmpc-devel gettext-devel rsync readline-devel which
+sudo dnf install wget gcc gcc-c++ python git perl-Pod-Simple gperf patch autoconf automake make makedepend bison flex gmp-devel mpfr-devel libmpc-devel gettext-devel rsync readline-devel which
 ```
 
 ### Ubuntu, Debian
 ```
-sudo apt install make wget git gcc g++ libgmp-dev libmpfr-dev libmpc-dev flex bison gettext ncurses-dev autoconf rsync libreadline-dev
+sudo apt install make wget git gcc g++ libgmp-dev libmpfr-dev libmpc-dev flex bison gettext autoconf rsync libreadline-dev
 ```
 
 If building with a normal user, the `PREFIX` directory must be writable (default is `/opt/amiga`). You can add the user to an appropriate group. 
@@ -108,13 +108,13 @@ Install cygwin via setup.exe and add wget. Then open cygwin shell and run:
 ```
 wget https://raw.githubusercontent.com/transcode-open/apt-cyg/master/apt-cyg
 install apt-cyg /bin
-apt-cyg install gcc-core gcc-g++ python git perl-Pod-Simple gperf patch automake make makedepend bison flex libncurses-devel python-devel gettext-devel libgmp-devel libmpc-devel libmpfr-devel rsync
+apt-cyg install gcc-core gcc-g++ python git perl-Pod-Simple gperf patch automake make makedepend bison flex python-devel gettext-devel libgmp-devel libmpc-devel libmpfr-devel rsync
 ```
 
 ### Windows with msys2
 
 ```
-pacman -S git base-devel gcc flex gmp-devel mpc-devel mpfr-devel ncurses-devel rsync autoconf automake
+pacman -S git base-devel gcc flex gmp-devel mpc-devel mpfr-devel rsync autoconf automake
 ```
 
 Also note that you **MUST** cd into an **absolute path** e.g. `cd /c/msys64/home/test/amiga-gcc/` before running make, or builds may fail, because some files aren't found correctly (that's a msys2 bug).


### PR DESCRIPTION
Stops requiring ncurses to build gdb, so the shipped Linux
`m68k-amigaos-gdb` no longer links it. ncurses' runtime ABI (soname bumps,
the libtinfo split) differs between distros, so a gdb built against the CI
image's ncurses is awkward to run elsewhere; the TUI is the feature that
pulled it in.

- drop `--enable-tui` from `CONFIG_BINUTILS` (native build; the cross/MinGW
  builds already `--disable-gdb`). The TUI is now autodetected rather than
  forced, so a local build in an environment that has ncurses still gets it
  -- only the flag that required it is gone.
- drop `libncurses-dev` from the Linux CI deps, and ncurses from the README
  prerequisite lists (Fedora, Debian/Ubuntu, Cygwin, msys2).

macOS needs no change: it never installed ncurses explicitly (it ships in
the base system/SDK), so gdb autodetects it there and keeps the TUI.

Note: gdb's bundled readline can still pick up a termcap/tinfo library for
line editing if one is present. This PR's own toolchain build exercises
`make all` (binutils + gdb), so CI confirms gdb still builds without the
ncurses dev package.

Python in gdb is intentionally left untouched: it is expected to be needed
for the Amiga support scripting.
