### PR TITLE
workflow: module-callable toolchain CI with per-platform labels

### DIFF
--- a/.github/scripts/override-repos.sh
+++ b/.github/scripts/override-repos.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
-# Apply module source overrides from the workflow's `repos` input to .repos.
-# Each space-separated word in $REPOS is module=branch or module=URL#branch.
+# Apply module source overrides from the workflow's `repos` input to the
+# build tree. Each space-separated word in $REPOS is one of:
+#   module=branch     - select a branch on the module's default remote
+#   module=URL#ref    - build ref (a branch or an exact commit sha) from URL
 # Run after the gcc branch has been selected and before `make update`, so a
 # module=branch form is not overwritten by the gcc branch selection.
 set -e
@@ -9,8 +11,24 @@ for spec in $REPOS; do
 	ref=${spec#*=}
 	grep -q "^$mod[[:blank:]]" .repos || { echo "unknown module: $mod"; exit 1; }
 	case "$ref" in
-		*"#"*) sed -i "s|^$mod[[:blank:]].*|$mod ${ref%%#*} ${ref##*#}|" .repos ;;
-		*)     make branch mod="$mod" branch="$ref" ;;
+	*"#"*)
+		# Fetch the exact ref into projects/<mod> and check it out, so
+		# `make update` finds it in place and skips cloning. `git fetch`
+		# takes a branch or a commit sha, so passing a PR head sha here
+		# builds that exact revision even if the branch is force-pushed
+		# before the checkout runs.
+		url=${ref%%#*}
+		want=${ref##*#}
+		echo "fetching $mod from $url @ $want"
+		rm -rf "projects/$mod"
+		git init -q "projects/$mod"
+		git -C "projects/$mod" remote add origin "$url"
+		git -C "projects/$mod" fetch -q --depth 16 origin "$want"
+		git -C "projects/$mod" checkout -q FETCH_HEAD
+		;;
+	*)
+		make branch mod="$mod" branch="$ref"
+		;;
 	esac
 done
 cat .repos

--- a/.github/scripts/override-repos.sh
+++ b/.github/scripts/override-repos.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Apply module source overrides from the workflow's `repos` input to .repos.
+# Each space-separated word in $REPOS is module=branch or module=URL#branch.
+# Run after the gcc branch has been selected and before `make update`, so a
+# module=branch form is not overwritten by the gcc branch selection.
+set -e
+for spec in $REPOS; do
+	mod=${spec%%=*}
+	ref=${spec#*=}
+	grep -q "^$mod[[:blank:]]" .repos || { echo "unknown module: $mod"; exit 1; }
+	case "$ref" in
+		*"#"*) sed -i "s|^$mod[[:blank:]].*|$mod ${ref%%#*} ${ref##*#}|" .repos ;;
+		*)     make branch mod="$mod" branch="$ref" ;;
+	esac
+done
+cat .repos

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -135,24 +135,13 @@ jobs:
       - name: Select gcc branch
         run: make branch branch=amiga$GCC_VER mod=gcc
 
-      # build with a pull request from another module's repo: each
-      # word is module=branch, or module=URL#branch for a fork
+      # build with a pull request from another module's repo: each word in
+      # repos is module=branch, or module=URL#branch for a fork
       - name: Override module repos
         if: inputs.repos != ''
         env:
           REPOS: ${{ inputs.repos }}
-        run: |
-          for spec in $REPOS; do
-            mod=${spec%%=*}
-            ref=${spec#*=}
-            grep -q "^$mod[[:blank:]]" .repos || { echo "unknown module: $mod"; exit 1; }
-            if [[ "$ref" == *"#"* ]]; then
-              sed -i "s|^$mod[[:blank:]].*|$mod ${ref%%#*} ${ref##*#}|" .repos
-            else
-              make branch mod=$mod branch=$ref
-            fi
-          done
-          cat .repos
+        run: sh .github/scripts/override-repos.sh
 
       - name: Fetch sources
         run: make update
@@ -281,6 +270,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.checkout_repo }}
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Prepare native build tools
         run: |
@@ -297,8 +289,11 @@ jobs:
           command -v lha
 
       - name: Build AmigaOS hosted toolchain
+        env:
+          REPOS: ${{ inputs.repos }}
         run: |
           make branch mod=gcc branch="amiga$GCC_VER"
+          [ -z "$REPOS" ] || sh .github/scripts/override-repos.sh
           make update
           make gcc-prerequisites
           make -j "$(nproc)" all
@@ -354,6 +349,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.checkout_repo }}
+          ref: ${{ inputs.checkout_ref }}
 
       - name: Install host runner
         run: |
@@ -378,8 +376,11 @@ jobs:
 
       - name: Build MinGW hosted toolchain
         id: version
+        env:
+          REPOS: ${{ inputs.repos }}
         run: |
           make branch mod=gcc branch="amiga$GCC_VER"
+          [ -z "$REPOS" ] || sh .github/scripts/override-repos.sh
           make update
           make -j "$(nproc)" all
           make -j 4 all-sdk

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -53,6 +53,16 @@ on:
       build_hosted:
         type: boolean
         default: true
+      # a module repo's own CI calls this workflow to build its PR: it
+      # points checkout_repo/checkout_ref at this build tree (instead of
+      # the caller) and names the module in repos. Empty for every other
+      # trigger, where checkout falls back to this repo at the event ref.
+      checkout_repo:
+        type: string
+        default: ""
+      checkout_ref:
+        type: string
+        default: ""
   # Every new pull request revision builds the Linux, AmigaOS-hosted and
   # MinGW-hosted toolchains, and the fast amigaos.exp target testsuite runs
   # on every build. Labels request an additional specialized run of the
@@ -84,7 +94,13 @@ jobs:
       # slow; pin one that is fast and healthy from the CI runners
       AMINET_MIRROR: http://nl.aminet.net
     steps:
+      # empty repository/ref check out this repo at the triggering event's
+      # ref (the normal PR, dispatch and release paths); a module caller
+      # overrides them to build this tree with its module swapped in
       - uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.checkout_repo }}
+          ref: ${{ inputs.checkout_ref }}
 
       # PREFIX and NDK reach every make invocation through the environment
       - name: Set prefix

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -86,7 +86,6 @@ jobs:
       RUN_TESTSUITE: ${{ inputs.run_testsuite || github.event.label.name == 'ci-testsuite-c' }}
       RUN_TESTSUITE_CXX: ${{ inputs.run_cxx_testsuite || github.event.label.name == 'ci-testsuite-cxx' }}
       AMITOOLS_GIT: ${{ inputs.amitools_git || 'git+https://github.com/AmigaPorts/amitools.git' }}
-      NDK: "3.2"
       # not GCC_VERSION: the Makefile reads that from gcc's BASE-VER
       # (16.2.0b) for gcc's own lib/gcc/<target>/<version> layout
       GCC_VER: ${{ inputs.gcc_version || '16.2' }}
@@ -102,7 +101,7 @@ jobs:
           repository: ${{ inputs.checkout_repo }}
           ref: ${{ inputs.checkout_ref }}
 
-      # PREFIX and NDK reach every make invocation through the environment
+      # PREFIX reaches every make invocation through the environment
       - name: Set prefix
         run: echo "PREFIX=$HOME/m68k-amigaos-gcc-$GCC_VER" >> $GITHUB_ENV
 
@@ -260,7 +259,6 @@ jobs:
       HOST: m68k-amigaos
       BUILD_TRIPLET: x86_64-linux-gnu
       HOST_RUNNER: vamos -C 68040 --
-      NDK: "3.2"
       OWNGMP: "1"
       BUILD_CC: x86_64-linux-gnu-gcc -B/opt/build-binutils/
       BUILD_CXX: x86_64-linux-gnu-g++ -B/opt/build-binutils/
@@ -339,7 +337,6 @@ jobs:
       HOST: x86_64-w64-mingw32ucrt
       BUILD_TRIPLET: x86_64-linux-gnu
       HOST_RUNNER: wine
-      NDK: "3.2"
       OWNGMP: "1"
       BUILD_CC: x86_64-linux-gnu-gcc -B/opt/build-binutils/
       BUILD_CXX: x86_64-linux-gnu-g++ -B/opt/build-binutils/

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -63,27 +63,27 @@ on:
       checkout_ref:
         type: string
         default: ""
-  # Every new pull request revision builds the Linux, AmigaOS-hosted and
-  # MinGW-hosted toolchains, and the fast amigaos.exp target testsuite runs
-  # on every build. Labels request an additional specialized run of the
-  # merge commit:
-  #  - "ci-macos": macOS build
-  #  - "ci-testsuite-c": Linux build with the gcc C testsuite
-  #  - "ci-testsuite-cxx": Linux build with the g++ testsuite (slow)
-  #  - "ci-cross": Linux plus the AmigaOS and MinGW hosted toolchains
+  # Nothing builds on a plain push; add a label to build the merge commit,
+  # and re-add it to rebuild after pushing new commits:
+  #  - "ci-linux": the Linux toolchain (plus the fast amigaos.exp testsuite)
+  #  - "ci-macos": the macOS toolchain
+  #  - "ci-amigaos": the AmigaOS-hosted toolchain
+  #  - "ci-mingw": the MinGW-hosted toolchain
+  #  - "ci-testsuite-c": Linux toolchain with the gcc C testsuite
+  #  - "ci-testsuite-cxx": Linux toolchain with the g++ testsuite (slow)
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [labeled]
 
 jobs:
   build:
     if: >-
       github.event_name != 'pull_request' ||
-      github.event.action != 'labeled' ||
-      startsWith(github.event.label.name, 'ci')
+      contains(fromJSON('["ci-linux", "ci-macos", "ci-testsuite-c", "ci-testsuite-cxx"]'),
+               github.event.label.name)
     runs-on: ${{ inputs.runner || (github.event.label.name == 'ci-macos' && 'macos-15') || 'ubuntu-24.04' }}
     timeout-minutes: 300
     env:
-      RUN_TESTSUITE: ${{ inputs.run_testsuite || github.event.label.name == 'ci-testsuite' || github.event.label.name == 'ci-testsuite-c' }}
+      RUN_TESTSUITE: ${{ inputs.run_testsuite || github.event.label.name == 'ci-testsuite-c' }}
       RUN_TESTSUITE_CXX: ${{ inputs.run_cxx_testsuite || github.event.label.name == 'ci-testsuite-cxx' }}
       AMITOOLS_GIT: ${{ inputs.amitools_git || 'git+https://github.com/AmigaPorts/amitools.git' }}
       NDK: "3.2"
@@ -257,8 +257,7 @@ jobs:
   build_amigaos:
     name: Build AmigaOS hosted toolchain
     if: >-
-      (github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' || github.event.label.name == 'ci-cross')) ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'ci-amigaos') ||
       (github.event_name != 'pull_request' && inputs.build_hosted)
     runs-on: ubuntu-24.04
     timeout-minutes: 300
@@ -329,8 +328,7 @@ jobs:
     # here must not block the release of the other platforms
     continue-on-error: true
     if: >-
-      (github.event_name == 'pull_request' &&
-        (github.event.action != 'labeled' || github.event.label.name == 'ci-cross')) ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'ci-mingw') ||
       (github.event_name != 'pull_request' && inputs.build_hosted)
     runs-on: ubuntu-24.04
     timeout-minutes: 300

--- a/Dockerfile.mingw32
+++ b/Dockerfile.mingw32
@@ -28,7 +28,6 @@ ENV PATH="/opt/build-binutils:${PATH}" \
     HOST="x86_64-w64-mingw32ucrt" \
     BUILD_TRIPLET="x86_64-linux-gnu" \
     HOST_RUNNER="wine" \
-    NDK="3.2" \
     OWNGMP="1" \
     BUILD_CC="x86_64-linux-gnu-gcc -B/opt/build-binutils/" \
     BUILD_CXX="x86_64-linux-gnu-g++ -B/opt/build-binutils/"


### PR DESCRIPTION
Reworks the toolchain CI so module repos can validate their PRs against a
full toolchain build, and rationalises the labels. Commits:

1. **checkout inputs** - add `checkout_repo` / `checkout_ref`
   `workflow_call` inputs so a module repo can call this reusable workflow
   to build its PR: it checks out this build tree and swaps the module in
   via the existing `repos` input. Empty for every current trigger
   (in-repo PR, dispatch, release), where behaviour is unchanged.
2. **per-platform labels** - nothing builds on a plain push; label the PR
   to build the merge commit: `ci-linux`, `ci-macos`, `ci-amigaos`,
   `ci-mingw`, `ci-testsuite-c`, `ci-testsuite-cxx`. Drops the lumped
   `ci-cross` label and the legacy `ci-testsuite` alias; the `pull_request`
   trigger narrows to `[labeled]` (re-add a label to rebuild after a push).
3. **hosted-job overrides** - thread the checkout inputs and the module
   override into `build_amigaos` and `build_mingw` too. Addresses the
   Copilot review: a module PR labeled `ci-amigaos`/`ci-mingw` previously
   checked out the caller repo and ignored the PR branch. The `repos`
   override moves to `.github/scripts/override-repos.sh`, shared by all
   three build jobs. The script also pins an exact commit: a caller passing
   `module=URL#<sha>` gets that revision shallow-fetched into
   `projects/<module>`, so a force-push during the run can't change what is
   built (the branch form still works for `workflow_dispatch`).
4. **cleanup** - drop the redundant `NDK=3.2` (the Makefile already
   defaults to NDK3.2 when `NDK` is unset).

Companion caller workflows: AmigaPorts/gcc#33, AmigaPorts/binutils-gdb#14.
**Merge this first**, and enable this repo's Settings -> Actions -> General
-> Access -> "Accessible from repositories owned by AmigaPorts" so the
module repos may call this reusable workflow.
