### PR TITLE
workflow: split the native build into build_linux and build_macos

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -75,12 +75,13 @@ on:
     types: [labeled]
 
 jobs:
-  build:
+  build_linux:
+    name: Build Linux toolchain
     if: >-
       github.event_name != 'pull_request' ||
-      contains(fromJSON('["ci-linux", "ci-macos", "ci-testsuite-c", "ci-testsuite-cxx"]'),
+      contains(fromJSON('["ci-linux", "ci-testsuite-c", "ci-testsuite-cxx"]'),
                github.event.label.name)
-    runs-on: ${{ inputs.runner || (github.event.label.name == 'ci-macos' && 'macos-15') || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.runner || 'ubuntu-24.04' }}
     timeout-minutes: 300
     env:
       RUN_TESTSUITE: ${{ inputs.run_testsuite || github.event.label.name == 'ci-testsuite-c' }}
@@ -105,8 +106,7 @@ jobs:
       - name: Set prefix
         run: echo "PREFIX=$HOME/m68k-amigaos-gcc-$GCC_VER" >> $GITHUB_ENV
 
-      - name: Install build dependencies (Linux)
-        if: runner.os == 'Linux'
+      - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -114,22 +114,8 @@ jobs:
             gettext git libgmp-dev libmpfr-dev libmpc-dev libncurses-dev \
             rsync wget xz-utils
 
-      # Apple ships old or BSD versions of most build tools; put the brew
-      # GNU ones first on PATH under their plain names (gnubin) so the
-      # build machinery does not need BSD workarounds
-      - name: Install build dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install autoconf automake bison coreutils flex gettext \
-            gmp gnu-sed gnu-tar grep make mpfr libmpc wget xz
-          echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
-          echo "$(brew --prefix flex)/bin" >> $GITHUB_PATH
-          for pkg in coreutils gnu-sed gnu-tar grep make; do
-            echo "$(brew --prefix $pkg)/libexec/gnubin" >> $GITHUB_PATH
-          done
-
       - name: Set build parallelism
-        run: echo "NPROC=$(nproc 2>/dev/null || sysctl -n hw.ncpu)" >> $GITHUB_ENV
+        run: echo "NPROC=$(nproc)" >> $GITHUB_ENV
 
       - name: Select gcc branch
         run: make branch branch=amiga$GCC_VER mod=gcc
@@ -187,13 +173,8 @@ jobs:
           path: log/
           if-no-files-found: ignore
 
-      - name: Install testsuite dependencies (Linux)
-        if: runner.os == 'Linux'
+      - name: Install testsuite dependencies
         run: sudo apt-get install -y --no-install-recommends dejagnu python3-dev python3-venv
-
-      - name: Install testsuite dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: brew install dejagnu
 
       - name: Install amitools (vamos)
         run: |
@@ -210,7 +191,7 @@ jobs:
           exit $rc
 
       - name: Run the gcc C testsuite
-        if: env.RUN_TESTSUITE == 'true' && runner.os == 'Linux'
+        if: env.RUN_TESTSUITE == 'true'
         run: |
           set +e
           PATH="$HOME/amitools-venv/bin:$PATH" make -j $NPROC check-gcc-execute
@@ -220,7 +201,7 @@ jobs:
 
       # much slower than the C testsuite, so it is opted into separately
       - name: Run the g++ testsuite
-        if: env.RUN_TESTSUITE_CXX == 'true' && runner.os == 'Linux'
+        if: env.RUN_TESTSUITE_CXX == 'true'
         run: |
           set +e
           PATH="$HOME/amitools-venv/bin:$PATH" make -j $NPROC check-gcc-c++
@@ -240,6 +221,115 @@ jobs:
             build-*/gcc/gcc/testsuite/gcc/gcc-amigaos.log
             build-*/gcc/gcc/testsuite/g++/g++.sum
             build-*/gcc/gcc/testsuite/g++/g++.log
+          if-no-files-found: ignore
+
+  build_macos:
+    name: Build macOS toolchain
+    if: github.event_name == 'pull_request' && github.event.label.name == 'ci-macos'
+    runs-on: macos-15
+    timeout-minutes: 300
+    env:
+      AMITOOLS_GIT: ${{ inputs.amitools_git || 'git+https://github.com/AmigaPorts/amitools.git' }}
+      GCC_VER: ${{ inputs.gcc_version || '16.2' }}
+      AMINET_MIRROR: http://nl.aminet.net
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.checkout_repo }}
+          ref: ${{ inputs.checkout_ref }}
+
+      - name: Set prefix
+        run: echo "PREFIX=$HOME/m68k-amigaos-gcc-$GCC_VER" >> $GITHUB_ENV
+
+      # Apple ships old or BSD versions of most build tools; put the brew GNU
+      # ones first on PATH under their plain names (gnubin) so the build
+      # machinery does not need BSD workarounds
+      - name: Install build dependencies
+        run: |
+          brew install autoconf automake bison coreutils flex gettext \
+            gmp gnu-sed gnu-tar grep make mpfr libmpc wget xz
+          echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
+          echo "$(brew --prefix flex)/bin" >> $GITHUB_PATH
+          for pkg in coreutils gnu-sed gnu-tar grep make; do
+            echo "$(brew --prefix $pkg)/libexec/gnubin" >> $GITHUB_PATH
+          done
+
+      - name: Set build parallelism
+        run: echo "NPROC=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
+
+      - name: Select gcc branch
+        run: make branch branch=amiga$GCC_VER mod=gcc
+
+      - name: Override module repos
+        if: inputs.repos != ''
+        env:
+          REPOS: ${{ inputs.repos }}
+        run: sh .github/scripts/override-repos.sh
+
+      - name: Fetch sources
+        run: make update
+
+      - name: Build toolchain
+        run: make -j $NPROC all
+
+      - name: Install SDKs
+        run: make -j4 all-sdk
+
+      - name: Build vbcc toolchain
+        run: make -j $NPROC vbcc vlink
+
+      - name: Build zlib and libpng
+        run: make -j $NPROC zlib libpng
+
+      - name: Package
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            make package \
+              PACKAGE=m68k-amigaos-gcc-${GITHUB_REF_NAME#v}-$(uname -s)-$(uname -m).tar.xz
+          else
+            make package
+          fi
+
+      - name: Upload toolchain tarball
+        uses: actions/upload-artifact@v7
+        with:
+          name: m68k-amigaos-gcc-${{ env.GCC_VER }}-${{ runner.os }}-${{ runner.arch }}
+          path: m68k-amigaos-gcc-*.tar.xz
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Upload build logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-logs-${{ runner.os }}
+          path: log/
+          if-no-files-found: ignore
+
+      - name: Install testsuite dependencies
+        run: brew install dejagnu
+
+      - name: Install amitools (vamos)
+        run: |
+          python3 -m venv $HOME/amitools-venv
+          $HOME/amitools-venv/bin/pip install "amitools[vamos] @ $AMITOOLS_GIT"
+
+      - name: Run the AmigaOS target testsuite
+        run: |
+          set +e
+          PATH="$HOME/amitools-venv/bin:$PATH" make -j $NPROC check-gcc-amigaos
+          rc=$?
+          { echo '```'; cat check-gcc-amigaos.summary.txt 2>/dev/null; echo '```'; } >> $GITHUB_STEP_SUMMARY
+          exit $rc
+
+      - name: Upload testsuite results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: testsuite-results-${{ runner.os }}
+          path: |
+            build-*/gcc/gcc/testsuite/gcc/gcc-amigaos.sum
+            build-*/gcc/gcc/testsuite/gcc/gcc-amigaos.log
           if-no-files-found: ignore
 
   build_amigaos:


### PR DESCRIPTION
Splits the shared native `build` job so a PR can build each platform on its
own:

- **build_linux** - the old `build` job, renamed and made Linux-only
  (`ci-linux`, `ci-testsuite-c`, `ci-testsuite-cxx`); keeps the gcc C/C++
  testsuites.
- **build_macos** - new job for the macOS build (`ci-macos`); builds and
  runs the `amigaos.exp` target testsuite, matching what the macOS side of
  the shared job did.

`build_amigaos` and `build_mingw` are unchanged, and label gating stays
one-label-per-run as today. The steps are the same as before, just moved
into two jobs (inline; no composite-action extraction here).

Scoped deliberately small. Deferred to later PRs: collapsing the per-run
"skipped" checks into a single run (label-set gating + a concurrency
group), and de-duplicating the shared steps between the two jobs.
