### PR TITLE
packaging: CPU-first cpu-os platform names and versioned lha layout

### DIFF
--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -166,7 +166,7 @@ jobs:
         run: |
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             make package \
-              PACKAGE=m68k-amigaos-gcc-${GITHUB_REF_NAME#v}-$(uname -s)-$(uname -m).tar.xz
+              PACKAGE=m68k-amigaos-gcc-${GITHUB_REF_NAME#v}-$(uname -m)-$(uname -s | tr '[:upper:]' '[:lower:]').tar.xz
           else
             make package
           fi
@@ -255,7 +255,7 @@ jobs:
       run:
         shell: bash
     env:
-      PREFIX: ${{ github.workspace }}/output/amigaos/m68k-amigaos-native
+      PREFIX: ${{ github.workspace }}/output/amigaos/m68k-amigaos-gcc-${{ inputs.gcc_version || '16.2' }}
       HOST: m68k-amigaos
       BUILD_TRIPLET: x86_64-linux-gnu
       HOST_RUNNER: vamos -C 68040 --

--- a/Makefile
+++ b/Makefile
@@ -615,7 +615,9 @@ drop-prefix:
 # on which the produced tools run.  PACKAGE_PLATFORM may be overridden for a
 # more user-facing platform label without changing the configured HOST.
 ifeq (,$(strip $(HOST)))
-PACKAGE_PLATFORM ?= $(UNAME_S)-$(shell uname -m)
+# short CPU-first cpu-os pair (x86_64-linux, arm64-darwin), stable across
+# distros unlike a full config triple; cross/hosted builds use $(HOST) below
+PACKAGE_PLATFORM ?= $(shell uname -m)-$(shell uname -s | tr '[:upper:]' '[:lower:]')
 else
 PACKAGE_PLATFORM ?= $(HOST)
 endif


### PR DESCRIPTION
Two packaging consistency fixes noticed on rc8.

**1. CPU-first platform names.** The native Linux/macOS tarballs were named
`<os>-<arch>` from uname (`Linux-x86_64`, `Darwin-arm64`), while the
cross/hosted artifacts are CPU-first (`x86_64-w64-mingw32ucrt`,
`m68k-amigaos`). Name the native ones as a short CPU-first `cpu-os` pair
from uname so all four read CPU-first:

| rc8 | rc9+ |
| --- | --- |
| `...-Linux-x86_64.tar.xz` | `...-x86_64-linux.tar.xz` |
| `...-Darwin-arm64.tar.xz` | `...-arm64-darwin.tar.xz` |
| `...-m68k-amigaos.lha` | unchanged |
| `...-x86_64-w64-mingw32ucrt-setup.exe` | unchanged |

uname is stable across distros; a full config triple's vendor field drifts
(`x86_64-linux-gnu` on Ubuntu vs `x86_64-redhat-linux` on Fedora), so the
short pair is used rather than the full triplet.

**2. Versioned .lha layout.** The AmigaOS `.lha` unpacked to a directory
named `m68k-amigaos-native` (the internal build PREFIX), whereas the Linux
tarball unpacks to `m68k-amigaos-gcc-16.2`. Point build_amigaos's PREFIX at
`m68k-amigaos-gcc-<gcc_version>` so both match.

Only affects future releases; rc8's published assets keep their names.
