### PR TITLE
build: fix the update deepen loop hanging on a detached HEAD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -660,10 +660,10 @@ update: update-gcc update-binutils update-fd2sfd update-fd2pragma update-ira upd
 	+$(MAKE) -B $(DOWNLOAD)/$(LIBFREETYPE).tar.xz
 
 update-gcc: $(PROJECTS)/gcc/configure
-	@cd $(PROJECTS)/gcc && git pull || (export DEPTH=16; while true; do echo "trying depth=$$DEPTH"; git pull --depth $$DEPTH && break; export DEPTH=$$(($$DEPTH+$$DEPTH));done)
+	@cd $(PROJECTS)/gcc && (git pull --ff-only || git fetch --unshallow || git fetch --deepen 100 || true)
 
 update-binutils: $(PROJECTS)/binutils/configure
-	@cd $(PROJECTS)/binutils && git pull || (export DEPTH=16; while true; do echo "trying depth=$$DEPTH"; git pull --depth $$DEPTH && break; export DEPTH=$$(($$DEPTH+$$DEPTH));done)
+	@cd $(PROJECTS)/binutils && (git pull --ff-only || git fetch --unshallow || git fetch --deepen 100 || true)
 
 update-fd2sfd: $(PROJECTS)/fd2sfd/configure
 	@cd $(PROJECTS)/fd2sfd && git pull


### PR DESCRIPTION
## Problem

Binutils/gcc PR CI runs get stuck for hours. The `toolchain.yml` build does:

1. `override-repos.sh` pins the PR module by `git checkout FETCH_HEAD` -> **detached HEAD**
2. `make update` -> `update-binutils` runs `git pull`, which fails with *"You are not currently on a branch"*, then enters the fallback:
   ```
   git pull || (DEPTH=16; while true; do git pull --depth $DEPTH && break; DEPTH=$((DEPTH+DEPTH)); done)
   ```
   Every `git pull --depth N` fails for the *same* reason (detached HEAD, nothing to merge), so the loop never `break`s and just doubles `DEPTH` forever -- past 2^31/2^32 where git rejects it -- until the job times out.

The loop's premise is wrong: it assumes the pull failed because the shallow clone is too shallow, but a detached HEAD can never be deepened into a mergeable state.

## Fix

Replace the loop in `update-gcc`/`update-binutils` with:

```
git pull --ff-only || git fetch --unshallow || git fetch --deepen 100 || true
```

- on a branch (fresh CI clone of gcc): `git pull --ff-only` succeeds
- detached / pinned override (binutils PR): pull fails, `git fetch --unshallow` (or `--deepen 100`) deepens history without a merge and without moving the pinned SHA
- never loops, never overflows, never fails the build