### PR TITLE
ci: record module revisions in the testsuite summary

### DIFF
--- a/.github/scripts/module-revisions.sh
+++ b/.github/scripts/module-revisions.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Print a markdown table of the checked-out module revisions to stdout, so a
+# build (its testsuite counts, its release tarball) can be tied to the exact
+# sources it came from. Loops over every git checkout under projects/, so new
+# modules need no change here. Run from the build tree root; the workflow
+# appends the output to the run summary, but it works standalone for testing.
+set -u
+
+echo "### Module revisions"
+echo "| module | latest commit |"
+echo "|---|---|"
+for d in projects/*/; do
+  [ -d "$d/.git" ] || continue
+  line=$(git -C "$d" log -1 --format='`%h` %s' 2>/dev/null) || continue
+  printf '| %s | %s |\n' "$(basename "$d")" "$(printf '%s' "$line" | tr '|' '/')"
+done

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -145,6 +145,10 @@ jobs:
       - name: Fetch sources
         run: make update
 
+      # provenance for the whole build, independent of the testsuite
+      - name: Record module revisions
+        run: sh .github/scripts/module-revisions.sh >> $GITHUB_STEP_SUMMARY
+
       - name: Build toolchain
         run: make -j $NPROC all
 


### PR DESCRIPTION
Print each project module's commit at the top of every build summary (via a standalone .github/scripts/ script), so a testsuite count or release tarball can be tied to the exact sources. Loops all projects/ checkouts; runs even with no testsuite.