### PR TITLE
Doc and cosmetic cleanups

### DIFF
--- a/COPYING-THIRD-PARTY.md
+++ b/COPYING-THIRD-PARTY.md
@@ -1,0 +1,29 @@
+# COPYRIGHTS
+
+* amiga-netinclude: 'Roadshow' -- Amiga TCP/IP stack, Copyright (C) 2001-2016 by Olaf Barthel. Freely Distributable.
+* aros-stuff: libpthread, Copyright (C) 2014 Szilard Biro.
+* binutils: Free Software Foundation, GNU GENERAL PUBLIC LICENSE V2.
+* clib2: Copyright (c) 2002-2015 by Olaf Barthel.
+* fd2pragma: Dirk Stoecker, public domain.
+* fd2sfd: Martin Blom et al, GNU GENERAL PUBLIC LICENSE V2.
+* gcc: Free Software Foundation, GNU GENERAL PUBLIC LICENSE V2.
+* ira: Tim Ruehsen, Ilkka Lehtoranta, Frank Wille, Nicolas Bastien. Freeware.
+* ixemul: Markus Wild, Rafael W. Luebbert, Leonard Norrgard, Jeff Shepherd, Matthias Fleischer, Hans Verkuil. GNU GENERAL PUBLIC LICENSE V2.
+* libdebug: ?, GNU GENERAL PUBLIC LICENSE V2.
+* libnix: Matthias Fleischer, Gunther Nikl. Public Domain.
+* NDK3.2: Hyperion, unknown license...
+* newlib: Free Software Foundation, GNU GENERAL PUBLIC LICENSE V2.
+* sfdc: Martin Blom, GNU GENERAL PUBLIC LICENSE V2.
+* vasm: copyright in 2002-2022 by Volker Barthelmann, free for non-commercial purposes.
+* vbcc: copyright in 1995-2022 by Volker Barthelmann, free for non-commercial purposes.
+* vlink: copyright 1995-2022 by Frank Wille, free for non-commercial purposes.
+
+There are also libraries (SDKs) which can be downloaded and installed. These
+libraries can all be built from source. All of these libraries are provided
+under their respective licenses.
+
+AmigaOS-specific changes are maintained in the upstream AmigaPorts repositories.
+The optional `patches/<module>/` directories can still be used for downstream patches,
+but no GCC or binutils patches are required by default. None of these changes modify
+the original copyright in any way. All other changes are published under the terms of
+the GNU GENERAL PUBLIC LICENSE V2.

--- a/Makefile
+++ b/Makefile
@@ -483,27 +483,30 @@ x:
 # =================================================
 .PHONY: help
 help:
-	@echo "make help					display this help"
-	@echo "make info					print prefix and other flags"
-	@echo "make all 					build and install all"
-	@echo "make min 					build and install the minimal to use gcc"
-	@echo "make <target>					builds a target: binutils, gcc, gprof, fd2sfd, fd2pragma, ira, sfdc, vasm, vbcc, vlink, libnix, ixemul, libgcc, clib2, libdebug, libpthread, ndk, ndk13"
-	@echo "make clean					remove the build folder"
-	@echo "make clean-<target>				remove the target's build folder"
-	@echo "make drop-prefix				remove all content from the prefix folder"
-	@echo "make package [PACKAGE_FORMAT=tar.xz|lha]	package the prefix folder for the destination host"
-	@echo "make package-lha				package the prefix folder as an .lha archive"
-	@echo "make update					perform git pull for all targets"
-	@echo "make update-<target>				perform git pull for the given target"
-	@echo "make sdk=<sdk>					install the sdk <sdk>"
-	@echo "make all-sdk					install all sdks"
-	@echo "make l   					print the last log entry for each project"
-	@echo "make b   					print the branch for each project"
-	@echo "make r   					print the remote for each project"
-	@echo "make v [date=<date>]				checkout all projects for a given date, checkout to branch if no date given"
-	@echo "make branch branch=<branch> mod=<module>	switch the module to the given branch"
+	@echo "make help                display this help"
+	@echo "make info                print prefix and other flags"
+	@echo "make all                 build and install all"
+	@echo "make min                 build and install the minimal to use gcc"
+	@echo "make <target>            builds a target: binutils, gcc, gprof, fd2sfd, fd2pragma, ira, sfdc, vasm, vbcc, vlink, libnix, ixemul, libgcc, clib2, libdebug, libpthread, ndk, ndk13"
+	@echo "make clean               remove the build folder"
+	@echo "make clean-<target>      remove the target's build folder"
+	@echo "make drop-prefix         remove all content from the prefix folder"
+	@echo "make package             package the prefix folder for the destination host"
+	@echo "make package-lha         package the prefix folder as an .lha archive"
+	@echo "make update              perform git pull for all targets"
+	@echo "make update-<target>     perform git pull for the given target"
+	@echo "make sdk=<sdk>           install the sdk <sdk>"
+	@echo "make all-sdk             install all sdks"
+	@echo "make l                   print the last log entry for each project"
+	@echo "make b                   print the branch for each project"
+	@echo "make r                   print the remote for each project"
+	@echo "make v [date=<date>]     checkout all projects for a given date, checkout to branch if no date given"
+	@echo "make branch branch=<branch> mod=<module>  switch the module to the given branch"
 	@echo ""
-	@echo "the optional parameter THREADS=posix will build it with thread support"
+	@echo "Parameters:"
+	@echo "PREFIX=<path>            defaults to /opt/amiga"
+	@echo "THREADS=posix            build gcc with thread support"
+	@echo "ADDLANG=lang,lang...     configure additional language frontends"
 
 # =================================================
 # all
@@ -755,10 +758,6 @@ update-mpc:
 	@$(MAKE) $(PROJECTS)/$(MPC)/configure
 
 # =================================================
-# B I N
-# =================================================
-
-# =================================================
 # binutils
 # =================================================
 CONFIG_BINUTILS = --prefix=$(PREFIX) --target=$(TARGET) $(HOST_CONFIGURE) --disable-werror --disable-nls --without-msgpack
@@ -853,7 +852,7 @@ $(BUILD)/binutils/_gdb: $(BUILD)/binutils/_done
 # =================================================
 # gprof
 # =================================================
-CONFIG_GRPOF := --prefix=$(PREFIX) --target=$(TARGET) $(HOST_CONFIGURE) --disable-werror
+CONFIG_GPROF := --prefix=$(PREFIX) --target=$(TARGET) $(HOST_CONFIGURE) --disable-werror
 
 gprof: $(BUILD)/binutils/_gprof
 
@@ -864,7 +863,7 @@ $(BUILD)/binutils/_gprof: $(BUILD)/binutils/gprof/Makefile $(shell find 2>/dev/n
 
 $(BUILD)/binutils/gprof/Makefile: $(PROJECTS)/binutils/configure $(BUILD)/binutils/_done
 	@mkdir -p $(BUILD)/binutils/gprof
-	$(L0)"configure gprof"$(L1) cd $(BUILD)/binutils/gprof && $(E) $(PROJECTS)/binutils/gprof/configure $(CONFIG_GRPOF) $(L2)
+	$(L0)"configure gprof"$(L1) cd $(BUILD)/binutils/gprof && $(E) $(PROJECTS)/binutils/gprof/configure $(CONFIG_GPROF) $(L2)
 
 # =================================================
 # gcc
@@ -1055,7 +1054,7 @@ $(BUILD)/gcc-host-compat.o: support/amiga-host-compat.c
 	$(L0)"make Amiga host compatibility object"$(L1) $(CC) $(CFLAGS) -c $< -o $@ $(L2)
 
 $(PROJECTS)/gcc/configure:
-	@cd $(PROJECTS) &&	git clone -b $(gcc_BRANCH) --depth 16 $(gcc_URL)
+	@cd $(PROJECTS) && git clone -b $(gcc_BRANCH) --depth 16 $(gcc_URL)
 	for i in $$(find patches/gcc/ -type f 2>/dev/null); \
 	do if [[ "$$i" == *.diff ]] ; \
 		then j=$${i:8}; patch -N "$(PROJECTS)/$${j%.diff}" "$$i"; fi ; done
@@ -1149,7 +1148,7 @@ $(BUILD_TOOLS)/fd2sfd/Makefile: $(PROJECTS)/fd2sfd/configure
 	$(L0)"configure fd2sfd for the build machine"$(L1) cd $(BUILD_TOOLS)/fd2sfd && CC="$(BUILD_CC)" CFLAGS="$(BUILD_CFLAGS)" $(PROJECTS)/fd2sfd/configure --prefix=$(BUILD_TOOLS_PREFIX) --target=$(TARGET) $(L2)
 
 $(PROJECTS)/fd2sfd/configure:
-	@cd $(PROJECTS) &&	git clone -b $(fd2sfd_BRANCH) --depth 4 $(fd2sfd_URL)
+	@cd $(PROJECTS) && git clone -b $(fd2sfd_BRANCH) --depth 4 $(fd2sfd_URL)
 	for i in $$(find patches/fd2sfd/ -type f); \
 	do if [[ "$$i" == *.diff ]] ; \
 		then j=$${i:8}; patch -N "$(PROJECTS)/$${j%.diff}" "$$i"; fi ; done
@@ -1188,7 +1187,7 @@ $(BUILD_TOOLS)/fd2pragma/fd2pragma: $(PROJECTS)/fd2pragma/makefile $(shell find 
 	$(L0)"make fd2pragma for the build machine"$(L1) cd $(PROJECTS)/fd2pragma && $(BUILD_CC) -o $@ $(BUILD_CFLAGS) fd2pragma.c $(L2)
 
 $(PROJECTS)/fd2pragma/makefile:
-	@cd $(PROJECTS) &&	git clone -b $(fd2pragma_BRANCH) --depth 4 $(fd2pragma_URL)
+	@cd $(PROJECTS) && git clone -b $(fd2pragma_BRANCH) --depth 4 $(fd2pragma_URL)
 
 # =================================================
 # ira
@@ -1207,7 +1206,7 @@ $(BUILD)/ira/ira$(EXEEXT): $(PROJECTS)/ira/Makefile $(shell find 2>/dev/null $(P
 	$(L0)"make ira"$(L1) cd $(PROJECTS)/ira && $(CC) -o $@ $(CFLAGS) *.c -std=c99 $(LDFLAGS) $(L2)
 
 $(PROJECTS)/ira/Makefile:
-	@cd $(PROJECTS) &&	git clone -b $(ira_BRANCH) --depth 4 $(ira_URL)
+	@cd $(PROJECTS) && git clone -b $(ira_BRANCH) --depth 4 $(ira_URL)
 
 # =================================================
 # sfdc
@@ -1229,7 +1228,7 @@ $(BUILD)/sfdc/Makefile: $(PROJECTS)/sfdc/configure $(shell find 2>/dev/null $(PR
 	$(L0)"configure sfdc"$(L1) cd $(BUILD)/sfdc && $(E) $(BUILD)/sfdc/configure $(CONFIG_SFDC) $(L2)
 
 $(PROJECTS)/sfdc/configure:
-	@cd $(PROJECTS) &&	git clone -b $(sfdc_BRANCH) --depth 4 $(sfdc_URL)
+	@cd $(PROJECTS) && git clone -b $(sfdc_BRANCH) --depth 4 $(sfdc_URL)
 
 # =================================================
 # vasm
@@ -1279,7 +1278,7 @@ $(BUILD_TOOLS)/vasm/Makefile: $(PROJECTS)/vasm/Makefile $(shell find 2>/dev/null
 	@touch $(BUILD_TOOLS)/vasm/Makefile
 
 $(PROJECTS)/vasm/Makefile:
-	@cd $(PROJECTS) &&	git clone -b $(vasm_BRANCH) --depth 4 $(vasm_URL)
+	@cd $(PROJECTS) && git clone -b $(vasm_BRANCH) --depth 4 $(vasm_URL)
 
 # =================================================
 # vbcc
@@ -1305,7 +1304,7 @@ $(BUILD)/vbcc/Makefile: $(PROJECTS)/vbcc/Makefile $(shell find 2>/dev/null $(PRO
 	@touch $(BUILD)/vbcc/Makefile
 
 $(PROJECTS)/vbcc/Makefile:
-	@cd $(PROJECTS) &&	git clone -b $(vbcc_BRANCH) --depth 4 $(vbcc_URL)
+	@cd $(PROJECTS) && git clone -b $(vbcc_BRANCH) --depth 4 $(vbcc_URL)
 
 # =================================================
 # vlink
@@ -1325,7 +1324,7 @@ $(BUILD)/vlink/Makefile: $(PROJECTS)/vlink/Makefile
 	@rsync -a --no-group $(PROJECTS)/vlink $(BUILD)/ --exclude .git
 
 $(PROJECTS)/vlink/Makefile:
-	@cd $(PROJECTS) &&	git clone -b $(vlink_BRANCH) --depth 4 $(vlink_URL)
+	@cd $(PROJECTS) && git clone -b $(vlink_BRANCH) --depth 4 $(vlink_URL)
 
 # Always built, so the toolchain ships its own lha instead of relying
 # on the host: brew only has lhasa, which cannot create archives and
@@ -1398,9 +1397,6 @@ $(DOWNLOAD)/vbcc_target_m68k-kick13.lha:
 $(DOWNLOAD)/vbcc_target_m68k-amigaos.lha:
 	$(call get-file,vbcc_target,http://aminet.net/dev/c/vbcc_target_m68k-amiga.lha,vbcc_target_m68k-amigaos.lha)
 
-# =================================================
-# L I B R A R I E S
-# =================================================
 # =================================================
 # NDK - no git
 # =================================================
@@ -1544,7 +1540,7 @@ $(BUILD)/_netinclude: $(PROJECTS)/amiga-netinclude/README.md $(BUILD)/ndk-includ
 	@echo "done" >$@
 
 $(PROJECTS)/amiga-netinclude/README.md:
-	@cd $(PROJECTS) &&	git clone -b $(amiga-netinclude_BRANCH) --depth 4 $(amiga-netinclude_URL)
+	@cd $(PROJECTS) && git clone -b $(amiga-netinclude_BRANCH) --depth 4 $(amiga-netinclude_URL)
 
 # =================================================
 # libamiga
@@ -1583,7 +1579,7 @@ $(BUILD)/libnix/_done: $(BUILD)/newlib/_done $(BUILD)/ndk-include_ndk $(BUILD)/n
 	@echo "done" >$@
 
 $(PROJECTS)/libnix/Makefile.gcc6:
-	@cd $(PROJECTS) &&	git clone -b $(libnix_BRANCH) --depth 4 $(libnix_URL)
+	@cd $(PROJECTS) && git clone -b $(libnix_BRANCH) --depth 4 $(libnix_URL)
 
 # =================================================
 # gcc libs
@@ -1649,7 +1645,7 @@ $(BUILD)/libdebug/Makefile: $(BUILD)/gcc/_libgcc_done $(BUILD)/libnix/_done $(PR
 	$(L0)"configure libdebug"$(L1) cd $(BUILD)/libdebug && LD=$(TARGET)-ld CC=$(TARGET)-gcc CFLAGS="$(CFLAGS_FOR_TARGET)" $(PROJECTS)/libdebug/configure $(CONFIG_LIBDEBUG) $(L2)
 
 $(PROJECTS)/libdebug/configure:
-	@cd $(PROJECTS) &&	git clone -b $(libdebug_BRANCH) --depth 4 $(libdebug_URL)
+	@cd $(PROJECTS) && git clone -b $(libdebug_BRANCH) --depth 4 $(libdebug_URL)
 	@touch -t 0001010000 $(PROJECTS)/libdebug/configure.ac
 
 # =================================================
@@ -1678,7 +1674,7 @@ $(BUILD)/libpthread/Makefile: $(BUILD)/libnix/_done $(PROJECTS)/aros-stuff/pthre
 	@touch $(BUILD)/libpthread/Makefile
 
 $(PROJECTS)/aros-stuff/pthreads/Makefile:
-	@cd $(PROJECTS) &&	git clone -b $(aros-stuff_BRANCH) --depth 4 $(aros-stuff_URL)
+	@cd $(PROJECTS) && git clone -b $(aros-stuff_BRANCH) --depth 4 $(aros-stuff_URL)
 
 # =================================================
 # newlib
@@ -1718,13 +1714,13 @@ $(BUILD)/newlib/newlib/Makefile: $(PROJECTS)/newlib-cygwin/newlib/configure $(BU
 	; else touch "$(BUILD)/newlib/newlib/Makefile"; fi
 
 $(PROJECTS)/newlib-cygwin/newlib/configure:
-	@cd $(PROJECTS) &&	git clone -b $(newlib-cygwin_BRANCH) --depth 4  $(newlib-cygwin_URL)
+	@cd $(PROJECTS) && git clone -b $(newlib-cygwin_BRANCH) --depth 4 $(newlib-cygwin_URL)
 
 # =================================================
 # ixemul
 # =================================================
 $(PROJECTS)/ixemul/configure:
-	@cd $(PROJECTS) &&	git clone -b $(ixemul_BRANCH) $(ixemul_URL)
+	@cd $(PROJECTS) && git clone -b $(ixemul_BRANCH) $(ixemul_URL)
 
 .PHONY: ixemul
 ixemul:	$(PREFIX)/$(TARGET)/ixemul/lib/libc.a

--- a/README.md
+++ b/README.md
@@ -24,36 +24,13 @@ Currently, these tools are built:
 # Branches
 ## Notable branches of gcc
 * `amiga6`: The legacy gcc-6.5.0b branch
-* `amiga10.4`: gcc-10.4.0  supports register parameters
-* `amiga13.4`: gcc-13.4.0  supports register parameters
-* `amiga15.2`: gcc-15.2.0  supports register parameters
+* `amiga10.4`: gcc-10.4.0
+* `amiga13.4`: gcc-13.4.0
+* `amiga15.2`: gcc-15.2.0
 * `amiga16.2`: gcc-16.2.0, the default branch, built and tested by CI
 
 ## Notable branches of binutils
 * `amiga-2.46`: binutils 2.46 with amigaos support and dwarf2 debugging (the default)
-
-# COPYRIGHTS
-* amiga-netinclude: 'Roadshow' -- Amiga TCP/IP stack, Copyright © 2001-2016 by Olaf Barthel. Freely Distributable.
-* aros-stuff: libpthread, Copyright (C) 2014 Szilard Biro.
-* binutils: Free Software Foundation, GNU GENERAL PUBLIC LICENSE V2.
-* clib2: Copyright (c) 2002-2015 by Olaf Barthel.
-* fd2pragma: Dirk Stoecker, public domain.
-* fd2sfd: Martin Blom et al, GNU GENERAL PUBLIC LICENSE V2.
-* gcc: Free Software Foundation, GNU GENERAL PUBLIC LICENSE V2.
-* ira: Tim Ruehsen, Ilkka Lehtoranta, Frank Wille, Nicolas Bastien. Freeware.
-* ixemul: Markus Wild, Rafael W. Luebbert, Leonard Norrgard, Jeff Shepherd, Matthias Fleischer, Hans Verkuil. GNU GENERAL PUBLIC LICENSE V2.
-* libdebug: ?, GNU GENERAL PUBLIC LICENSE V2.
-* libnix: Matthias Fleischer, Gunther Nikl. Public Domain.
-* NDK3.2: Hyperion, unknown license...
-* newlib: Free Software Foundation, GNU GENERAL PUBLIC LICENSE V2.
-* sfdc: Martin Blom, GNU GENERAL PUBLIC LICENSE V2.
-* vasm: copyright in 2002-2022 by Volker Barthelmann, free for non-commercial purposes.
-* vbcc: copyright in 1995-2022 by Volker Barthelmann, free for non-commercial purposes.
-* vlink: copyright 1995-2022 by Frank Wille, free for non-commercial purposes.
-
-There are also libraries (SDKs) which can be downloaded and installed. These libraries can all be built from source. All of these libraries are provided under their respective licenses.
-
-AmigaOS-specific changes are maintained in the upstream AmigaPorts repositories. The optional `patches/<module>/` directories can still be used for downstream patches, but no GCC or binutils patches are required by default. None of these changes modify the original copyright in any way. All other changes are published under the terms of the GNU GENERAL PUBLIC LICENSE V2.
 
 ## Prerequisites
 ### Fedora
@@ -173,9 +150,7 @@ sudo usermod -a -G users username
 After adding the user to the group, you may have to logout and login again to apply the changes to your user.
 
 ## Building
-Once the `PREFIX` directory is writable, run `make all`. You can use
-`-j` to speed up the build, adjusting the value of `-j` to the number
-of cores you wish to use for the build process.
+Once the `PREFIX` directory is writable, run `make all`. You can use `-j$(nproc)` to speed up the build.
 
 ```
 make clean
@@ -292,28 +267,6 @@ make branch mod=binutils branch=devel1
 ```
 The default branches and repositories are in the file **default-repos**, the local state is managed in the file **.repos**.
 
-The default GCC branch is `amiga16.2`; see the Branches section above
-for the alternatives. A fresh build can therefore be started directly:
-```
-sudo mkdir -p /opt/amiga16
-sudo chown $USER /opt/amiga16
-git clone https://github.com/AmigaPorts/m68k-amigaos-gcc
-cd m68k-amigaos-gcc
-export PREFIX=/opt/amiga16
-make all -j$(nproc)
-```
+# Copyrights
 
-## Fortran support
-m68k-amigaos-gfortran is available now too. To build it add `ADDLANG=fortran`:
-```
-make all -j20 ADDLANG=fortran
-```
-
-The example from https://gcc.gnu.org/wiki/GFortranGettingStarted does work, you have to link using gcc:
-```
-> m68k-amigaos-gfortran -Os fprog.f90 -c
-> m68k-amigaos-gcc -Os -noixemul sub.c -c
-> m68k-amigaos-gcc fprog.o sub.o  -o fprog -lgfortran -noixemul -lm
-> vamos fprog
-abcd 5 4711 4712.000000 13 14
-```
+See [COPYING](COPYING) and [COPYING-THIRD-PARTY](COPYING-THIRD-PARTY.md).

--- a/README.md
+++ b/README.md
@@ -1,38 +1,31 @@
 # m68k-amigaos-gcc
 
-The GNU C Compiler with binutils and other useful tools for cross
-compiling software for AmigaOS. This is the AmigaPorts continuation of
-bebbo's amiga-gcc; fixes flow both ways.
-
-This is a Makefile based approach to building the amigaos-toolchain, aiming to reduce its build time.
+The GNU C Compiler with binutils and other useful tools for cross compiling software for AmigaOS.
+This is the AmigaPorts continuation of bebbo's amiga-gcc; fixes flow both ways.
 
 Currently, these tools are built:
 
-* binutils
-* gcc with libs for C/C++/ObjC
-* fd2sfd
-* fd2pragma
-* ira
-* sfdc
-* vasm
-* vbcc
-* vlink
-* libnix
-* newlib
-* clib2
+* binutils with Hunk binary format support
+* gcc with frontends for C/C++/ObjC
+* libnix, newlib, clib2
+* sfdc, fd2sfd, fd2pragma
+* vbcc, vasm, vlink
+* ira (m68k reassembler)
 
-# Branches
-## Notable branches of gcc
+## Branches
+### Notable branches of gcc
 * `amiga6`: The legacy gcc-6.5.0b branch
 * `amiga10.4`: gcc-10.4.0
 * `amiga13.4`: gcc-13.4.0
 * `amiga15.2`: gcc-15.2.0
 * `amiga16.2`: gcc-16.2.0, the default branch, built and tested by CI
 
-## Notable branches of binutils
+### Notable branches of binutils
 * `amiga-2.46`: binutils 2.46 with amigaos support and dwarf2 debugging (the default)
 
+
 ## Prerequisites
+
 ### Fedora
 ```
 sudo dnf install wget gcc gcc-c++ python git perl-Pod-Simple gperf patch autoconf automake make makedepend bison flex gmp-devel mpfr-devel libmpc-devel gettext-devel rsync readline-devel which
@@ -42,8 +35,6 @@ sudo dnf install wget gcc gcc-c++ python git perl-Pod-Simple gperf patch autocon
 ```
 sudo apt install make wget git gcc g++ libgmp-dev libmpfr-dev libmpc-dev flex bison gettext autoconf rsync libreadline-dev
 ```
-
-If building with a normal user, the `PREFIX` directory must be writable (default is `/opt/amiga`). You can add the user to an appropriate group. 
 
 ### macOS
 Install Homebrew (https://brew.sh/) or any other package manager first. The compiler will be installed together with XCode. Once XCode and Homebrew are up install the required packages:
@@ -74,20 +65,6 @@ done
 CC=gcc-12 CXX=g++-12 gmake all
 ```
 
-* This version of gcc supports building binaries optimised for the various Motorola 68K series CPUs from the 68000 to the 68060 and also features some optimisations for the Vampire/Apollo 68080.
-
-### macOS on M1
-Native builds on M1 Macs are now directly supported.
-
-### Windows with Cygwin
-Install cygwin via setup.exe and add wget. Then open cygwin shell and run:
-
-```
-wget https://raw.githubusercontent.com/transcode-open/apt-cyg/master/apt-cyg
-install apt-cyg /bin
-apt-cyg install gcc-core gcc-g++ python git perl-Pod-Simple gperf patch automake make makedepend bison flex python-devel gettext-devel libgmp-devel libmpc-devel libmpfr-devel rsync
-```
-
 ### Windows with msys2
 
 ```
@@ -96,10 +73,9 @@ pacman -S git base-devel gcc flex gmp-devel mpc-devel mpfr-devel rsync autoconf 
 
 Also note that you **MUST** cd into an **absolute path** e.g. `cd /c/msys64/home/test/amiga-gcc/` before running make, or builds may fail, because some files aren't found correctly (that's a msys2 bug).
 
-### Ubuntu running on the Windows 10 Linux subsystem
-same as normal ubuntu
 
-## Howto Clone and Download All You Need
+## Cloning and Downloading Sources
+
 ```
 git clone https://github.com/AmigaPorts/m68k-amigaos-gcc
 cd m68k-amigaos-gcc
@@ -109,47 +85,28 @@ make update
 The default configuration builds GCC 16.2. Use `make branch` as described
 under Version management if you need a different GCC branch.
 
-## Overview
-```
-make help
-```
-yields:
-```
-make help 		        display this help
-make all 		          build and install all
-make <target>		      builds a target: binutils, gcc, fd2sfd, fd2pragma, ira, sfdc, vbcc, vlink, libnix, ixemul, libgcc
-make clean		        remove the build folder
-make clean-<target>	  remove the target's build folder
-make drop-prefix	    remove all content from the prefix folder, beware!
-make package		      package the prefix folder as .tar.xz (default) or .lha
-make package-lha	      package the prefix folder as .lha
-make check		        run the gcc testsuite against the built toolchain, using vamos as simulator
-make update		        perform git pull for all targets
-make update-<target>	perform git pull for the given target
-```
-display which targets can be build, you'll mostly use
-*`make all`
-*`make clean`
-*`make drop-prefix`
+Use `make help` to see which targets can be built.
 
-to use NDK3.2 add `NDK=3.2` to the make parameters
+## Install Prefix
 
-## Prefix
-The default prefix is `/opt/amiga`. You may specify a different prefix by adding `PREFIX=yourprefix` to make command. E.g.
-```
-make all PREFIX=/here/or/there
-```
-The build performs the installation automatically, there is no separate `make install` step. Because of this, you must make sure that the target `PREFIX` directory is writable for the user who is doing the build.
-If the `PREFIX` directory points to a directory where the user already has appropriate permissions the below steps can be ommited and the directory will be created by the build process.
+The build performs the installation automatically, there is no separate `make install` step.
+
+The default prefix is `/opt/amiga`. You must make sure that the target `PREFIX` directory
+is writable for the user who is doing the build:
+
 ```
 sudo mkdir /opt/amiga
-sudo chgrp users /opt/amiga
-sudo chmod 775 /opt/amiga
-sudo usermod -a -G users username
+sudo chown $(id -u):$(id -g) /opt/amiga
 ```
-After adding the user to the group, you may have to logout and login again to apply the changes to your user.
+
+You may specify a different prefix by adding `PREFIX=<path>` to the make commands:
+
+```
+make all PREFIX=$HOME/m68k-amiga-gcc
+```
 
 ## Building
+
 Once the `PREFIX` directory is writable, run `make all`. You can use `-j$(nproc)` to speed up the build.
 
 ```
@@ -157,67 +114,49 @@ make clean
 make drop-prefix
 time make all -j$(nproc)
 ```
-A full bootstrap takes roughly 10 to 30 minutes on current Linux
-hardware, dominated by serial configure and multilib phases.
+A full bootstrap takes roughly 10 to 30 minutes on current Linux hardware, dominated by multilib phases.
 
 ## Packaging
-`make package` packages the PREFIX folder as `.tar.xz` by default. Native
-builds use the build machine's OS and architecture in the filename. Cross
-builds use `HOST`, so their filenames identify the system on which the tools
+This packages the PREFIX folder into a redistributable archive:
+
+```
+make package      # builds a .tar.xz archive
+make package-lha  # builds a .lha archive
+```
+Native builds use the build machine's OS and architecture in the filename.
+Cross builds use `HOST`, so their filenames identify the system on which the tools
 will run rather than the build machine.
 
-Select an LHA archive with `PACKAGE_FORMAT=lha` or the `package-lha`
-convenience target:
-
-```
-make package PACKAGE_FORMAT=lha
-make package-lha
-```
-
-For example, `HOST=m68k-amigaos` produces a filename ending in
-`-m68k-amigaos.tar.xz` or `-m68k-amigaos.lha`. Override the platform label
-with `PACKAGE_PLATFORM=` and the complete output path with `PACKAGE=`:
-
-```
-make package PREFIX=/opt/amiga PACKAGE=/tmp/toolchain.tar.xz
-make package-lha PREFIX=/opt/amiga PACKAGE_PLATFORM=AmigaOS-m68k
-```
-
-## Continuous integration and releases
+## Continuous integration
 The GitHub Actions workflow in `.github/workflows/toolchain.yml`
 bootstraps the toolchain from scratch, optionally runs the gcc
 testsuite under vamos, and uploads the native `.tar.xz` packages as build
-artifacts. By default it also Canadian-cross-builds the `amiga16.2` compiler
-for AmigaOS and MinGW hosts, using the published
-`amigadev/crosstools:m68k-amigaos-gcc10` and
-`amigadev/crosstools:x86_64-w64-mingw32` build environments. The local hosted
+artifacts.
+
+By default it also Canadian-cross-builds the `amiga16.2` compiler for AmigaOS
+and MinGW hosts, using the published `amigadev/crosstools:m68k-amigaos-gcc10`
+and `amigadev/crosstools:x86_64-w64-mingw32` build environments. The local hosted
 build Dockerfiles are not rebuilt by CI. The AmigaOS package is an `.lha`; the
 Windows runner uses the files in `setup/` to compile an Inno Setup installer
 without running the generated installer. If installer compilation fails, the
 workflow uploads a portable `.zip` instead.
 
-Pushing a tag matching `v*` additionally publishes the tarball as a
-GitHub release, with the gcc testsuite as a release gate.
+## Releases
 
-## Kickstart 1.3
-
-If you plan to develop for Kickstart 1.3 you should use `-mcrt=nix13` in your compiler commandline
-
-```
-m68k-amigaos-gcc test.cpp -mcrt=nix13
-```
-
-The include files for 1.3 - which are picked up by the compiler if `-mcrt=nix13` is used - can be found at `<PREFIX>/m68k-amigaos/ndk13-include` i.E. `/opt/amiga/m68k-amigaos/ndk13-include`
+Pushing a tag matching `v*` publishes the binary archives as a GitHub release,
+with the gcc testsuite as a release gate.
 
 ## Libraries/Runtimes
 
-You can select one of the various runtimes. My favorite is `libnix` which is selected by specifying `-noixemul` or `-mcrt=nix20`. Always specify this as the last parameter and only once. These are the available runtimes:
+You can select one of the various runtimes:
 
-* nothing specifed: newlib based libraries for Kickstart 2.0+
-* `-noixemul` or `-mcrt=nix20`: the libnix libraries for Kickstart 2.0+
-* `-mcrt=nix13`: the libnix libraries for Kickstart 1.3
-* `-mcrt=clib2`: the clib2 libraries.
-* `-mcrt=ixemul`: the ixemul libraries for Kickstart 2.0+, requires an installed `ixemul.library`
+* Nothing specified: newlib-based static runtime for Kickstart 2.0+ (still the default, but uncommon nowadays)
+* `-mcrt=nix20` or `-noixemul`: the libnix runtime for Kickstart 2.0+ (recommended option for most projects)
+* `-mcrt=nix13`: the libnix static runtime for Kickstart 1.3 (also uses headers from `<PREFIX>/m68k-amigaos/ndk13-include`)
+* `-mcrt=clib2`: the clib2 static runtime
+* `-mcrt=ixemul`: the ixemul dynamic runtime for Kickstart 2.0+, requires an installed `ixemul.library`
+
+Always specify this as the last parameter and only once.
 
 ## Checking gcc
 
@@ -267,6 +206,6 @@ make branch mod=binutils branch=devel1
 ```
 The default branches and repositories are in the file **default-repos**, the local state is managed in the file **.repos**.
 
-# Copyrights
+## Copyrights
 
 See [COPYING](COPYING) and [COPYING-THIRD-PARTY](COPYING-THIRD-PARTY.md).

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ with the gcc testsuite as a release gate.
 
 You can select one of the various runtimes:
 
-* Nothing specified: newlib-based static runtime for Kickstart 2.0+ (still the default, but uncommon nowadays)
-* `-mcrt=nix20` or `-noixemul`: the libnix runtime for Kickstart 2.0+ (recommended option for most projects)
+* Nothing specified: newlib-based static runtime for Kickstart 2.0+ (**default, but uncommon nowadays**)
+* `-mcrt=nix20` or `-noixemul`: the libnix runtime for Kickstart 2.0+ (**recommended option for most projects**)
 * `-mcrt=nix13`: the libnix static runtime for Kickstart 1.3 (also uses headers from `<PREFIX>/m68k-amigaos/ndk13-include`)
 * `-mcrt=clib2`: the clib2 static runtime
 * `-mcrt=ixemul`: the ixemul dynamic runtime for Kickstart 2.0+, requires an installed `ixemul.library`

--- a/default-repos
+++ b/default-repos
@@ -9,7 +9,6 @@ ixemul             https://github.com/AmigaPorts/ixemul             master
 lha                https://github.com/AmigaPorts/lha                master
 libdebug           https://github.com/AmigaPorts/libdebug           master
 libnix             https://github.com/AmigaPorts/libnix             master
-libSDL12           https://github.com/AmigaPorts/libSDL12           master
 newlib-cygwin      https://github.com/AmigaPorts/newlib-cygwin      amiga
 sfdc               https://github.com/AmigaPorts/sfdc               master
 vasm               https://github.com/AmigaPorts/vasm               master


### PR DESCRIPTION
Realign the `make help` text and document ADDLANG, fix the CONFIG_GPROF typo, drop the orphan section banners and the unused libSDL12 entry in default-repos, normalize whitespace in the clone recipes, and move the third-party copyright list out of the README into COPYING-THIRD-PARTY.md. No functional change.