### PR TITLE
Makefile: skip git pull for module checkouts pinned to a commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -661,56 +661,64 @@ update: update-gcc update-binutils update-fd2sfd update-fd2pragma update-ira upd
 	+$(MAKE) -B $(DOWNLOAD)/$(LIBPNG).tar.xz
 	+$(MAKE) -B $(DOWNLOAD)/$(LIBFREETYPE).tar.xz
 
+# Pull a module checkout forward. A checkout pinned to an exact commit (CI
+# building a module's pull request) has no branch to pull, so it is left as
+# is; a shallow clone that cannot fast-forward is deepened instead.
+define update-module
+@cd $(PROJECTS)/$1 && if git symbolic-ref -q HEAD >/dev/null; then \
+	git pull --ff-only || git fetch --unshallow || git fetch --deepen 100 || true; fi
+endef
+
 update-gcc: $(PROJECTS)/gcc/configure
-	@cd $(PROJECTS)/gcc && (git pull --ff-only || git fetch --unshallow || git fetch --deepen 100 || true)
+	$(call update-module,gcc)
 
 update-binutils: $(PROJECTS)/binutils/configure
-	@cd $(PROJECTS)/binutils && (git pull --ff-only || git fetch --unshallow || git fetch --deepen 100 || true)
+	$(call update-module,binutils)
 
 update-fd2sfd: $(PROJECTS)/fd2sfd/configure
-	@cd $(PROJECTS)/fd2sfd && git pull
+	$(call update-module,fd2sfd)
 
 update-fd2pragma: $(PROJECTS)/fd2pragma/makefile
-	@cd $(PROJECTS)/fd2pragma && git pull
+	$(call update-module,fd2pragma)
 
 update-ira: $(PROJECTS)/ira/Makefile
-	@cd $(PROJECTS)/ira && git pull
+	$(call update-module,ira)
 
 update-sfdc: $(PROJECTS)/sfdc/configure
-	@cd $(PROJECTS)/sfdc && git pull
+	$(call update-module,sfdc)
 
 update-vasm: $(PROJECTS)/vasm/Makefile
-	@cd $(PROJECTS)/vasm && git pull
+	$(call update-module,vasm)
 
 update-vbcc: $(PROJECTS)/vbcc/Makefile
-	@cd $(PROJECTS)/vbcc && git pull
+	$(call update-module,vbcc)
 
 update-vlink: $(PROJECTS)/vlink/Makefile
-	@cd $(PROJECTS)/vlink && git pull
+	$(call update-module,vlink)
 
 update-libnix: $(PROJECTS)/libnix/Makefile.gcc6
-	@cd $(PROJECTS)/libnix && git pull
+	$(call update-module,libnix)
 
 update-ixemul: $(PROJECTS)/ixemul/configure
-	@cd $(PROJECTS)/ixemul && git pull
+	$(call update-module,ixemul)
 
 update-clib2: $(PROJECTS)/clib2/LICENSE
-	@cd $(PROJECTS)/clib2 && git pull
+	$(call update-module,clib2)
 
 update-libdebug: $(PROJECTS)/libdebug/configure
-	@cd $(PROJECTS)/libdebug && git pull
+	$(call update-module,libdebug)
 
 update-libpthread: $(PROJECTS)/aros-stuff/pthreads/Makefile
-	@cd $(PROJECTS)/aros-stuff && git pull
+	$(call update-module,aros-stuff)
 
 update-ndk: $(DOWNLOAD)/$(NDK_ARC_NAME).lha
 	$(MAKE) $(PROJECTS)/$(NDK_FOLDER_NAME).info
 
 update-newlib: $(PROJECTS)/newlib-cygwin/newlib/configure
-	@cd $(PROJECTS)/newlib-cygwin && git pull
+	$(call update-module,newlib-cygwin)
 
 update-netinclude: $(PROJECTS)/amiga-netinclude/README.md
-	@cd $(PROJECTS)/amiga-netinclude && git pull
+	$(call update-module,amiga-netinclude)
 
 .PHONY: gcc-prerequisites update-gmp update-mpc update-mpfr
 gcc-prerequisites: $(PROJECTS)/$(GMP)/configure $(PROJECTS)/$(MPFR)/configure $(PROJECTS)/$(MPC)/configure


### PR DESCRIPTION
A module fork's CI hook (gcc, binutils, now newlib-cygwin) builds its pull request by checking out the exact head sha via override-repos.sh, leaving the checkout on a detached HEAD. The later `make update` then failed with "You are not currently on a branch" for every module except gcc and binutils, which #85 had patched individually: see https://github.com/AmigaPorts/newlib-cygwin/actions/runs/33909722028.

Replace the 16 per-module pull lines with one `update-module` macro that skips the pull on a detached HEAD and otherwise keeps the #85 behavior (ff-only pull, deepen a shallow clone that cannot fast-forward). Tested locally on a detached checkout (no-op, exit 0) and on a branch (pulls as before).